### PR TITLE
flow the jti from the SIOP id token

### DIFF
--- a/lib/InputValidation/DidValidation.ts
+++ b/lib/InputValidation/DidValidation.ts
@@ -81,6 +81,9 @@ export class DidValidation implements IDidValidation {
      return validationResponse;
    }
 
+   // once the token is validated, we can trust the jti
+   validationResponse.jti = validationResponse.payloadObject.jti;
+
    console.log(`The signature is verified with DID ${validationResponse.did}`);
    return validationResponse;
   }

--- a/lib/InputValidation/IValidationResponse.ts
+++ b/lib/InputValidation/IValidationResponse.ts
@@ -70,4 +70,9 @@ export interface IValidationResponse {
    * All claims found in input tokens
    */
   validationResult?: IValidationResult;
+
+  /**
+   * the Json Web Token Id of the incoming token
+   */
+  jti?: string;
 }

--- a/tests/IssuanceHelpers.ts
+++ b/tests/IssuanceHelpers.ts
@@ -22,7 +22,8 @@ export class IssuanceHelpers {
       contract,
       attestations,
       iss: 'https://self-issued.me',
-      aud: setup.AUDIENCE
+      aud: setup.AUDIENCE,
+      jti: 'test-jti'
     }
 
     const claimToken = await IssuanceHelpers.signAToken(setup, JSON.stringify(siop), '', key);
@@ -191,7 +192,7 @@ export class IssuanceHelpers {
       upn: 'jules@pulpfiction.com',
       name: 'Jules Winnfield',
       iss: setup.tokenIssuer,
-      aud: setup.tokenAudience
+      aud: setup.tokenAudience,
     };
 
     const idToken = await IssuanceHelpers.signAToken(

--- a/tests/SiopValidation.spec.ts
+++ b/tests/SiopValidation.spec.ts
@@ -36,6 +36,8 @@ describe('SiopValidation', () =>
     const validator = new SiopValidation(validationOptions, expected);
     const response = await validator.validate(request.rawToken);
     expect(response.result).toBeTruthy();
+    expect(response.jti).toBeDefined();
+    expect(response.jti).toEqual(request.decodedToken.jti);
   });
   
   it('should return status 200', async () => {


### PR DESCRIPTION
**Problem:**
The Card Actions, the jti of the incoming request is needed 


**Solution:**
Set the jti during DIDValidation if it is present


**Validation:**
Added criteria to SIOP unit test


**Type of change:**
- [x ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


