### PR TITLE
update nyc to overcome run test problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jasmine-spec-reporter": "4.2.1",
     "jasmine-ts": "0.3.0",
     "node-fetch": "2.6.0",
-    "nyc": "^15.0.1",
+    "nyc": "^14.1.1",
     "source-map-support": "0.5.12",
     "ts-node": "8.1.0",
     "tslint": "5.16.0",


### PR DESCRIPTION
**Problem:**
nyc v13 and v15 is blocking run test

**Solution:**
update to v14
