### PR TITLE
Bug fixes to escape the Contract Id Name and also strip query parameters

### DIFF
--- a/lib/ApiValidation/Validator.ts
+++ b/lib/ApiValidation/Validator.ts
@@ -78,7 +78,7 @@ export default class Validator {
         case TokenType.siopIssuance:
           response = await validator.validate(queue, queueItem!);
           siopDid = response.did;
-          siopContractId = Validator.getContractIdFromSiop(response.payloadObject.contract);
+          siopContractId = Validator.readContractId(response.payloadObject.contract);
           break;
         case TokenType.siopPresentation:
           response = await validator.validate(queue, queueItem!);
@@ -167,14 +167,18 @@ export default class Validator {
   }
 
   /**
-   * Extract contract id from the siop contract url
-   * @param contractUrl The contract url
-   */
-  public static getContractIdFromSiop(contractUrl: string) {
-    const contractTypeSplitted = contractUrl.split('/');
-    const contractId = contractTypeSplitted[contractTypeSplitted.length - 1];
-    return contractId;
+   * for a given contract uri, get the id
+   * @param contractUrl the contract uri to extract the name from
+   * */
+  public static readContractId(contractUrl: string) {
+    const url = new URL(contractUrl);
+    let path = url.pathname;
+
+    const pathParts = path.split('/');
+    path = pathParts[pathParts.length - 1];
+    return decodeURIComponent(path);
   }
+
 
   /**
    * Check the token type based on the payload

--- a/tests/IdTokenValidation.spec.ts
+++ b/tests/IdTokenValidation.spec.ts
@@ -26,7 +26,7 @@ import { IExpectedIdToken, Validator } from '../lib';
     const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.idToken);   
     const expected = siop.expected.filter((token: IExpectedIdToken) => token.type === TokenType.idToken)[0];
 
-    let validator = new IdTokenValidation(options, expected, Validator.getContractIdFromSiop(siop.contract));
+    let validator = new IdTokenValidation(options, expected, Validator.readContractId(siop.contract));
     let response = await validator.validate(siop.idToken.rawToken)
     expect(response.result).toBeTruthy();
     

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -203,4 +203,27 @@ describe('Validator', () => {
     // Negative cases
 
   });
+
+  it('should read the contract id with no spaces', () => {
+    const id = 'foo';
+    const url = `https://test.com/v1.0/abc/def/contracts/${id}`;
+    const result = Validator.readContractId(url);
+    expect(result).toEqual(id);
+  });
+
+  it('should read the contract id with spaces', () => {
+    const id = 'foo bar';
+    const url = `https://test.com/v1.0/abc/def/contracts/${encodeURIComponent(id)}`;
+    const result = Validator.readContractId(url);
+    expect(result).toEqual(id);
+  });
+
+  it('should read the contract id with spaces and query', () => {
+    const id = 'foo bar';
+    const url = `https://test.com/v1.0/abc/def/contracts/${encodeURIComponent(id)}?qs=abcdefggh`;
+    const result = Validator.readContractId(url);
+    expect(result).toEqual(id);
+  });
+
+
 });


### PR DESCRIPTION
**Problem:**
Reading the contract id did not account for uri escaping nor query string


**Solution:**
uri decode the contract name and remove query string values
add unit tests


**Validation:**
unit tests


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
