### PR TITLE
only set contract id on successful validation

### DIFF
--- a/lib/ApiValidation/Validator.ts
+++ b/lib/ApiValidation/Validator.ts
@@ -84,7 +84,11 @@ export default class Validator {
         case TokenType.siopIssuance:
           response = await validator.validate(queue, queueItem!);
           siopDid = response.did;
-          siopContractId = Validator.readContractId(response.payloadObject.contract);
+
+          if (response.result) {
+            siopContractId = Validator.readContractId(response.payloadObject.contract);
+          }
+
           break;
         case TokenType.siopPresentation:
           response = await validator.validate(queue, queueItem!);


### PR DESCRIPTION
**Problem:**
Contract Id attempt to be set at all times, which meant on a failing validation a nullreference would occur


**Solution:**
Only set it on success


**Validation:**


**Type of change:**
- [ ] Feature work
- [x ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

