### PR TITLE
Only get the contract on successful validation

### DIFF
--- a/lib/ApiValidation/Validator.ts
+++ b/lib/ApiValidation/Validator.ts
@@ -78,7 +78,11 @@ export default class Validator {
           options = new ValidationOptions(validatorOption, claimToken.type);
           response = await validator.validate(queue, queueItem!);
           siopDid = response.did;
-          siopContract = Validator.readContractId(response.payloadObject.contract);
+
+          if (response.result) {
+            siopContract = Validator.readContractId(response.payloadObject.contract);
+          }
+
           break;
         case TokenType.selfIssued:
           options = new ValidationOptions(validatorOption, claimToken.type);


### PR DESCRIPTION
**Problem:**
Contract was always set regardless of whether or not the SIOP validation succeeded resulting in a null reference error


**Solution:**
Check for successful status of validation


**Validation:**


**Type of change:**
- [ ] Feature work
- [x ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


