### PR TITLE
allow the rules file to contain a scope value for the client to follow

### DIFF
--- a/lib/rules-model/IdTokenAttestationModel.ts
+++ b/lib/rules-model/IdTokenAttestationModel.ts
@@ -15,6 +15,7 @@ export class IdTokenAttestationModel extends BaseAttestationModel {
    * @param configuration url to an Open Id Connect Provider configuration
    * @param client_id if dynamic registration is not supported, the registered client to use for implicit authorization flows
    * @param redirect_uri if dynamic registration is not supported, the redirect_uri used for implicit authorization flows
+   * @param scope scope value to augment the required openid value
    * @param mapping a map of string to InputClaimModel instances
    * @param encrypted flag indicating if the attestation is encrypted
    * @param claims an array of InputClaimModel values
@@ -26,6 +27,7 @@ export class IdTokenAttestationModel extends BaseAttestationModel {
     public client_id?: string,
     // tslint:disable-next-line:variable-name
     public redirect_uri?: string,
+    public scope?: string,
     mapping?: { [map: string]: InputClaimModel }, 
     encrypted: boolean = false, 
     claims?: InputClaimModel[], 
@@ -49,6 +51,6 @@ export class IdTokenAttestationModel extends BaseAttestationModel {
    * @param claims Input claims
    */
   protected createForInput(claims: InputClaimModel[]): BaseAttestationModel {
-    return new IdTokenAttestationModel(this.configuration, this.client_id, this.redirect_uri, undefined, this.encrypted, claims, this.required);
+    return new IdTokenAttestationModel(this.configuration, this.client_id, this.redirect_uri, this.scope, undefined, this.encrypted, claims, this.required);
   }
 }

--- a/lib/rules-model/IdTokenAttestationModel.ts
+++ b/lib/rules-model/IdTokenAttestationModel.ts
@@ -44,6 +44,7 @@ export class IdTokenAttestationModel extends BaseAttestationModel {
     this.configuration = input.configuration;
     this.client_id = input.client_id;
     this.redirect_uri  = input.redirect_uri;
+    this.scope = input.scope;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.10.0-preview.0",
+  "version": "0.10.0",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.10.0",
+  "version": "0.10.0-preview.0",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/RequestorBuilder.spec.ts
+++ b/tests/RequestorBuilder.spec.ts
@@ -38,6 +38,7 @@ describe('RequestorBuilder', () => {
           'oidc config endpoint',
           'clientId',
           'redirect',
+          'scope',
           {
             email: new InputClaimModel('upn', 'string', false, true),
             name: new InputClaimModel('name')

--- a/tests/RulesModel.spec.ts
+++ b/tests/RulesModel.spec.ts
@@ -168,7 +168,10 @@ describe('TenantSourceFactory', () => {
     });
 
     it('Input model must correctly derive from Rules Model ', async () => {
-      const input = new InputModel(RULES);
+      const json = JSON.stringify(RULES);
+      const roundtrip = new RulesModel();
+      roundtrip.populateFrom(JSON.parse(json));
+      const input = new InputModel(roundtrip);
 
       expect(input.credentialIssuer).toEqual(RULES.credentialIssuer);
       expect(input.issuer).toEqual(RULES.issuer);
@@ -202,6 +205,7 @@ describe('TenantSourceFactory', () => {
 
       for (let i = 0; i < rulesIdTokens.length; i++) {
         expect(inputIdTokens[i].encrypted).toEqual(rulesIdTokens[i].encrypted);
+        expect(inputIdTokens[i].scope).toBeDefined();
         expect(inputIdTokens[i].scope).toEqual(rulesIdTokens[i].scope);
 
         rulesMap = rulesIdTokens[i].mapping;

--- a/tests/RulesModel.spec.ts
+++ b/tests/RulesModel.spec.ts
@@ -43,6 +43,7 @@ describe('TenantSourceFactory', () => {
           'oidc config endpoint',
           'clientId',
           'redirect',
+          'scope',
           {
             email: new InputClaimModel('upn', 'string', false, true),
             name: new InputClaimModel('name')
@@ -201,6 +202,7 @@ describe('TenantSourceFactory', () => {
 
       for (let i = 0; i < rulesIdTokens.length; i++) {
         expect(inputIdTokens[i].encrypted).toEqual(rulesIdTokens[i].encrypted);
+        expect(inputIdTokens[i].scope).toEqual(rulesIdTokens[i].scope);
 
         rulesMap = rulesIdTokens[i].mapping;
         claims = <InputClaimModel[]>inputIdTokens[i].claims;
@@ -240,6 +242,19 @@ describe('TenantSourceFactory', () => {
           expect(inputClaim.type).toEqual(value.type);
         });
       });
+    });
+
+    it('missing scope value is still valid', async () => {
+      const json = JSON.stringify(RULES);
+      const roundtrip = new RulesModel();
+      roundtrip.populateFrom(JSON.parse(json));
+
+      // setting the scope to undefined ensures back compat with existing contracts
+      roundtrip.attestations!.idTokens![0].scope = undefined;
+
+      // derive the input model from the modified rules file
+      const input = new InputModel(roundtrip);
+      expect(input.attestations!.idTokens![0].scope).toBeUndefined();
     });
 
     it('should pass populating the VerifiableCredentialModel without context ', async () => {


### PR DESCRIPTION
add test case to ensure existing rule files without scope continue to work

**Problem:**
The rules file does not allow a way to specify scope for the client in the open id flow


**Solution:**
Provide a property in the ID Token Attestation class to specify a scope value that augments the required openid value


**Validation:**
Unit test to ensure the scope value propogates and that existing rules are backwards compatible


**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.
