### PR TITLE
Cleanup index to avoid fetch-mock package reference error

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,10 +33,10 @@ export { ValidationOptions, IValidationOptions, IValidatorOptions, BasicValidato
 
 import TestSetup from '../tests/TestSetup';
 import { IssuanceHelpers } from '../tests/IssuanceHelpers';
-import RequestorHelper from '../tests/RequestorHelper';
-import ResponderHelper from '../tests/ResponderHelper';
-import TokenGenerator from '../tests/TokenGenerator';
-export { TestSetup, IssuanceHelpers, ResponderHelper, RequestorHelper,  TokenGenerator }
+//import RequestorHelper from '../tests/RequestorHelper';
+//import ResponderHelper from '../tests/ResponderHelper';
+//import TokenGenerator from '../tests/TokenGenerator';
+export { TestSetup, IssuanceHelpers }
 
 import { IdTokenValidationResponse } from './input_validation/IdTokenValidationResponse';
 import { IValidationResponse } from './input_validation/IValidationResponse';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.10.0-preview.26",
+  "version": "0.10.0-preview.27",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
While using the SDK some installs have a failing reference to fetch-mock. Try to avoid this issue by removing some references from the index.