### PR TITLE
Add a name property to BaseAttestationModel and set it for each subclass

### DIFF
--- a/lib/rules_model/BaseAttestationModel.ts
+++ b/lib/rules_model/BaseAttestationModel.ts
@@ -26,6 +26,11 @@ export abstract class BaseAttestationModel {
   }
 
   /**
+   * Gets the name of the attestation
+   */
+  abstract get name(): string;
+
+  /**
    * Populate an instance of BaseAttestationModel from any instance
    * @param input object instance to populate from
    */

--- a/lib/rules_model/IdTokenAttestationModel.ts
+++ b/lib/rules_model/IdTokenAttestationModel.ts
@@ -36,6 +36,13 @@ export class IdTokenAttestationModel extends BaseAttestationModel {
   }
 
   /**
+   * Gets the name of the attestation
+   */
+  get name(): string {
+    return this.configuration!;
+  }
+
+  /**
    * Populate an instance of IdTokenAttestationModel from any instance
    * @param input object instance to populate from
    */

--- a/lib/rules_model/SelfIssuedAttestationModel.ts
+++ b/lib/rules_model/SelfIssuedAttestationModel.ts
@@ -10,6 +10,9 @@ import { BaseAttestationModel } from './BaseAttestationModel';
  * Model for defining Self Issued claims
  */
 export class SelfIssuedAttestationModel extends BaseAttestationModel {
+
+  public static readonly attestationName: string = 'selfAttested';
+
   /**
    *
    * @param mapping a map of string to InputClaimModel instances
@@ -19,6 +22,13 @@ export class SelfIssuedAttestationModel extends BaseAttestationModel {
    */
   constructor(mapping?: { [map: string]: InputClaimModel }, encrypted: boolean = false, claims?: InputClaimModel[], required: boolean = false) {
     super(mapping, encrypted, claims, required);
+  }
+
+  /**
+   * Gets the name of the attestation
+   */
+  get name(): string {
+    return SelfIssuedAttestationModel.attestationName;
   }
 
   /**

--- a/lib/rules_model/VerifiablePresentationAttestationModel.ts
+++ b/lib/rules_model/VerifiablePresentationAttestationModel.ts
@@ -37,6 +37,13 @@ export class VerifiablePresentationAttestationModel extends BaseAttestationModel
   }
 
   /**
+   * Gets the name of the attestation
+   */
+  get name(): string {
+    return this.credentialType!;
+  }
+
+  /**
    * Populate an instance of VerifiablePresentationModel from any instance
    * @param input object instance to populate from
    */

--- a/tests/RulesModel.spec.ts
+++ b/tests/RulesModel.spec.ts
@@ -187,6 +187,7 @@ describe('TenantSourceFactory', () => {
       const rulesSelfIssuedAttestation = <SelfIssuedAttestationModel>rulesAttestations.selfIssued;
       expect(inputSelfIssuedAttestation).toBeDefined();
       expect(inputSelfIssuedAttestation.encrypted).toEqual(rulesSelfIssuedAttestation.encrypted);
+      expect(inputSelfIssuedAttestation.name).toEqual(SelfIssuedAttestationModel.attestationName);
 
       // we are going to build a set of input and rules maps for comparison
       const allMaps = [];
@@ -207,6 +208,7 @@ describe('TenantSourceFactory', () => {
         expect(inputIdTokens[i].encrypted).toEqual(rulesIdTokens[i].encrypted);
         expect(inputIdTokens[i].scope).toBeDefined();
         expect(inputIdTokens[i].scope).toEqual(rulesIdTokens[i].scope);
+        expect(inputIdTokens[i].name).toEqual(rulesIdTokens[i].configuration!);
 
         rulesMap = rulesIdTokens[i].mapping;
         claims = <InputClaimModel[]>inputIdTokens[i].claims;
@@ -222,6 +224,7 @@ describe('TenantSourceFactory', () => {
 
       for (let i = 0; i < rulesPresentations.length; i++) {
         expect(inputPresentations[i].encrypted).toEqual(rulesPresentations[i].encrypted);
+        expect(inputPresentations[i].name).toEqual(rulesPresentations[i].credentialType!);
 
         rulesMap = rulesPresentations[i].mapping;
         claims = <InputClaimModel[]>inputPresentations[i].claims;


### PR DESCRIPTION
**Problem:**
BaseAttestationModel did not have a way to express a descriptor of a attestation


**Solution:**
Add an abstract property to the class that gets filled in at runtime


**Validation:**
Unit tests updated


**Type of change:**
- [ x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

