### PR TITLE
Beejones/refactor validation pipeline

### DIFF
--- a/lib/api_validation/ITokenValidator.ts
+++ b/lib/api_validation/ITokenValidator.ts
@@ -23,5 +23,13 @@ export default interface ITokenValidator {
    * @param queueItem under validation
    */
   validate(queue: ValidationQueue, queueItem: ValidationQueueItem, siopDid?: string, siopContract?: string): Promise<IValidationResponse>;
+  
+
+  /**
+   * Get tokens from current items and add them to the queue.
+   * @param validationResponse The response for the requestor
+   * @param queue with tokens to validate
+   */
+  getTokens(validationResponse: IValidationResponse, queue: ValidationQueue): IValidationResponse;
 }
 

--- a/lib/api_validation/IdTokenTokenValidator.ts
+++ b/lib/api_validation/IdTokenTokenValidator.ts
@@ -38,7 +38,16 @@ export default class IdTokenTokenValidator implements ITokenValidator {
     const validationResult = await validator.validate(queueItem.tokenToValidate);
     return validationResult as IValidationResponse;    
   }
-  
+
+  /**
+   * Get tokens from current item and add them to the queue.
+   * @param validationResponse The response for the requestor
+   * @param queue with tokens to validate
+   */
+  public getTokens(_validationResponse: IValidationResponse, _queue: ValidationQueue ): IValidationResponse {
+    throw new Error('Not implemented');
+  }
+
   /**
    * Gets the type of token to validate
    */

--- a/lib/api_validation/SelfIssuedTokenValidator.ts
+++ b/lib/api_validation/SelfIssuedTokenValidator.ts
@@ -39,7 +39,16 @@ export default class SelfIssuedTokenValidator implements ITokenValidator {
     
     return validationResponse;
   }
-  
+
+  /**
+   * Get tokens from current item and add them to the queue.
+   * @param validationResponse The response for the requestor
+   * @param queue with tokens to validate
+   */
+  public getTokens(_validationResponse: IValidationResponse, _queue: ValidationQueue ): IValidationResponse {
+    throw new Error('Not implemented');
+  }
+
   /**
    * Gets the type of token to validate
    */

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TokenType, IExpectedSiop, ITokenValidator } from '../index';
+import { TokenType, IExpectedSiop, ITokenValidator, ClaimToken } from '../index';
 import { IValidationResponse } from '../input_validation/IValidationResponse';
 import ValidationOptions from '../options/ValidationOptions';
 import IValidatorOptions from '../options/IValidatorOptions';
 import ValidationQueue from '../input_validation/ValidationQueue';
 import ValidationQueueItem from '../input_validation/ValidationQueueItem';
 import { SiopValidation } from '../input_validation/SiopValidation';
+import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
 
 /**
  * Class to validate a token
@@ -21,27 +22,87 @@ export default class SiopTokenValidator implements ITokenValidator {
    * @param validatorOption The options used during validation
    * @param expected values to find in the token to validate
    */
-  constructor (private validatorOption: IValidatorOptions, private expected: IExpectedSiop) {
+  constructor(private validatorOption: IValidatorOptions, private expected: IExpectedSiop) {
   }
 
- /**
-   * Validate the token
-   * @param queue with tokens to validate
-   * @param queueItem under validation
-   */
-  public async validate(queue: ValidationQueue, queueItem: ValidationQueueItem): Promise<IValidationResponse> { 
+  /**
+    * Validate the token
+    * @param queue with tokens to validate
+    * @param queueItem under validation
+    */
+  public async validate(queue: ValidationQueue, queueItem: ValidationQueueItem): Promise<IValidationResponse> {
     const options = new ValidationOptions(this.validatorOption, this.expected.type);
     const validator = new SiopValidation(options, this.expected);
-    const validationResult = await validator.validate(queueItem.tokenToValidate);
-    if (validationResult.tokensToValidate) {
-      for (let key in validationResult.tokensToValidate) {
-        queue.enqueueItem(new ValidationQueueItem(key, validationResult.tokensToValidate[key].rawToken, validationResult.tokensToValidate[key]));
-      }
+    let validationResult = await validator.validate(queueItem.tokenToValidate);
+    if (validationResult.result) {
+      validationResult = this.getTokens(validationResult, queue);
     }
+
     return validationResult as IValidationResponse;
   }
-  
-  
+
+  /**
+   * Get tokens from current item and add them to the queue.
+   * @param validationResponse The response for the requestor
+   * @param queue with tokens to validate
+   */
+  public getTokens(validationResponse: IValidationResponse, queue: ValidationQueue ): IValidationResponse {
+
+    // Check type of SIOP
+    let type: TokenType;
+    if (validationResponse.payloadObject[VerifiableCredentialConstants.ATTESTATIONS]) {
+      type = TokenType.siopPresentationAttestation;
+    } else if (validationResponse.payloadObject[VerifiableCredentialConstants.PRESENTATION_SUBMISSION]) {
+      type = TokenType.siopPresentationExchange;
+    } else {
+      return {
+        result: false,
+        status: 403,
+        detailedError: 'Could not get tokens from SIOP. Unrecognized format.'
+      }
+    }
+    switch (type) {
+      case TokenType.siopPresentationAttestation:
+        const attestations = validationResponse.payloadObject[VerifiableCredentialConstants.ATTESTATIONS];
+        if (attestations) {
+          // Decode tokens
+          try {
+            validationResponse.tokensToValidate = ClaimToken.getClaimTokensFromAttestations(attestations);
+          } catch (err) {
+            console.error(err);
+            return {
+              result: false,
+              status: 403,
+              detailedError: err.message
+            };
+          }
+        }
+        break;
+
+      case TokenType.siopPresentationExchange:
+        // Get presentation exchange tokens
+
+        // Decode tokens
+        try {
+          validationResponse.tokensToValidate = ClaimToken.getClaimTokensFromPresentationExchange(validationResponse.payloadObject);
+        } catch (err) {
+          console.error(err);
+          return {
+            result: false,
+            status: 403,
+            detailedError: err.message
+          };
+      }
+        break;
+    }
+    if (validationResponse.tokensToValidate) {
+      for (let key in validationResponse.tokensToValidate) {
+        queue.enqueueItem(new ValidationQueueItem(key, validationResponse.tokensToValidate[key].rawToken, validationResponse.tokensToValidate[key]));
+      }
+    }
+    return validationResponse;
+  }
+
   /**
    * Gets the type of token to validate
    */

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -97,7 +97,7 @@ export default class SiopTokenValidator implements ITokenValidator {
     }
     if (validationResponse.tokensToValidate) {
       for (let key in validationResponse.tokensToValidate) {
-        queue.enqueueItem(new ValidationQueueItem(key, validationResponse.tokensToValidate[key].rawToken, validationResponse.tokensToValidate[key]));
+        queue.enqueueItem(new ValidationQueueItem(key, validationResponse.tokensToValidate[key]));
       }
     }
     return validationResponse;

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -48,7 +48,7 @@ export default class Validator {
    * The validation handler
    * @param token to validate
    */
-  public async validate(token: string): Promise<IValidationResponse> {
+  public async validate(token: string | ClaimToken): Promise<IValidationResponse> {
     let response: IValidationResponse = {
       result: true,
       status: 200,
@@ -57,7 +57,19 @@ export default class Validator {
     let siopDid: string | undefined;
     let siopContractId: string | undefined;
     const queue = new ValidationQueue();
-    queue.enqueueToken('siop', token);
+    if (typeof token === 'string') {
+      claimToken = ClaimToken.create(token);
+    } else if (token instanceof ClaimToken) {
+      claimToken = token;
+    } else {
+      return {
+        result: false,
+        status: 500,
+        detailedError: 'Wrong token type. Expected string or ClaimToken'
+      }
+    }
+
+    queue.enqueueToken('siop', claimToken);
     let queueItem = queue.getNextToken();
     do {
       try {

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -58,7 +58,15 @@ export default class Validator {
     let siopContractId: string | undefined;
     const queue = new ValidationQueue();
     if (typeof token === 'string') {
-      claimToken = ClaimToken.create(token);
+      try {
+        claimToken = ClaimToken.create(token);
+      } catch (exception) {
+        return {
+          status: 400,
+          detailedError: exception.message,
+          result: false
+        }
+      }
     } else if (token instanceof ClaimToken) {
       claimToken = token;
     } else {

--- a/lib/api_validation/VerifiableCredentialTokenValidator.ts
+++ b/lib/api_validation/VerifiableCredentialTokenValidator.ts
@@ -39,6 +39,15 @@ export default class VerifiableCredentialTokenValidator implements ITokenValidat
     const validationResult = await validator.validate(queueItem.tokenToValidate, siopDid);
     return validationResult as IValidationResponse;
   }
+  
+  /**
+   * Get tokens from current item and add them to the queue.
+   * @param validationResponse The response for the requestor
+   * @param queue with tokens to validate
+   */
+  public getTokens(_validationResponse: IValidationResponse, _queue: ValidationQueue ): IValidationResponse {
+    throw new Error('Not implemented');
+  }
 
   /**
    * Gets the type of token to validate

--- a/lib/input_validation/SiopValidation.ts
+++ b/lib/input_validation/SiopValidation.ts
@@ -44,13 +44,7 @@ export class SiopValidation implements ISiopValidation {
     if (!validationResponse.result) {
       return validationResponse;
     }
-
-    // Get input for the requested VC
-    validationResponse = await this.options.getTokensFromSiopDelegate(validationResponse);
-    if (!validationResponse.result) {
-      return validationResponse;
-    }
-
+    
     console.log(`The SIOP signature is verified with DID ${validationResponse.did}`);
     return validationResponse;
   }

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -536,67 +536,6 @@ export class ValidationHelpers {
   }
 
   /**
-   * Decode the tokens from the SIOP request
-   * @param validationResponse The response for the requestor
-   * @returns validationResponse.result, validationResponse.status, validationResponse.detailedError
-   * @returns validationResponse.tokensToValidate List of tokens found in the SIOP
-   */
-  public getTokensFromSiop(validationResponse: IValidationResponse): IValidationResponse {
-    const self: any = this;
-
-    // Check type of SIOP
-    let type: TokenType;
-    if (validationResponse.payloadObject[VerifiableCredentialConstants.ATTESTATIONS]) {
-      type = TokenType.siopPresentationAttestation;
-    } else if (validationResponse.payloadObject[VerifiableCredentialConstants.PRESENTATION_SUBMISSION]) {
-      type = TokenType.siopPresentationExchange;
-    } else {
-      return {
-        result: false,
-        status: 403,
-        detailedError: 'Could not get tokens from SIOP. Unrecognized format.'
-      }
-    }
-
-    switch (type) {
-      case TokenType.siopPresentationAttestation:
-        const attestations = validationResponse.payloadObject[VerifiableCredentialConstants.ATTESTATIONS];
-        if (attestations) {
-          // Decode tokens
-          try {
-            validationResponse.tokensToValidate = ClaimToken.getClaimTokensFromAttestations(attestations);
-          } catch (err) {
-            console.error(err);
-            return {
-              result: false,
-              status: 403,
-              detailedError: err.message
-            };
-          }
-        }
-        break;
-
-      case TokenType.siopPresentationExchange:
-        // Get presentation exchange tokens
-
-        // Decode tokens
-        try {
-          validationResponse.tokensToValidate = ClaimToken.getClaimTokensFromPresentationExchange(validationResponse.payloadObject);
-        } catch (err) {
-          console.error(err);
-          return {
-            result: false,
-            status: 403,
-            detailedError: err.message
-          };
-        }
-        break;
-    }
-
-    return validationResponse;
-  }
-
-  /**
    * Validation a signed token 
    * @param validationResponse The response for the requestor
    * @param token Token to validate

--- a/lib/input_validation/ValidationQueue.ts
+++ b/lib/input_validation/ValidationQueue.ts
@@ -5,7 +5,7 @@
 
 import ValidationQueueItem from './ValidationQueueItem';
 import { IValidationResponse } from './IValidationResponse';
-import { TokenType } from '../verifiable_credential/ClaimToken';
+import ClaimToken, { TokenType } from '../verifiable_credential/ClaimToken';
 
 export default class ValidationQueue {
 
@@ -18,7 +18,7 @@ export default class ValidationQueue {
    * Add token to validation queue
    * @param token to add to queue
    */
-  public enqueueToken(id: string, token: string) {
+  public enqueueToken(id: string, token: ClaimToken) {
     this.queue.push(new ValidationQueueItem(id, token));
   }
 

--- a/lib/input_validation/ValidationQueueItem.ts
+++ b/lib/input_validation/ValidationQueueItem.ts
@@ -28,7 +28,7 @@ export default class ValidationQueueItem {
   private _validatedToken: ClaimToken | undefined;
   private validationStatus: ValidationStatus = ValidationStatus.todo;
 
-  constructor(private _id: string, private _tokenToValidate: string, private _claimToken?: ClaimToken) {
+  constructor(private _id: string, private _tokenToValidate: ClaimToken) {
     // Set defaults for validation result
     this._validationResult = {
       result: false,
@@ -65,7 +65,7 @@ export default class ValidationQueueItem {
    * Token to validate
    */
   public get tokenToValidate(): string {
-    return this._tokenToValidate;
+    return this._tokenToValidate.rawToken;
   }
 
   /**
@@ -100,6 +100,6 @@ export default class ValidationQueueItem {
    * A ClaimToken may have already been created elsewhere, get that reference
    */
   public get claimToken(): ClaimToken | undefined{
-    return this._claimToken;
+    return this._tokenToValidate;
   }
 }

--- a/lib/input_validation/VerifiablePresentationValidation.ts
+++ b/lib/input_validation/VerifiablePresentationValidation.ts
@@ -86,29 +86,13 @@ export class VerifiablePresentationValidation implements IVerifiablePresentation
         detailedError: `Missing or wrong default type in vp of presentation. Should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLEPRESENTATION_TYPE}`
       };
     }
-
-
-    validationResponse.tokensToValidate = this.setVcTokens(validationResponse.payloadObject.vp.verifiableCredential);
-    if (!validationResponse.tokensToValidate) {
+    if (!validationResponse.payloadObject.vp['verifiableCredential']) {
       return {
         result: false,
         status: 403,
         detailedError: `Missing verifiableCredential in presentation`
       };
     }
-
     return validationResponse;
-  }
-
-  private setVcTokens(vc: string[]) {
-    if (!vc) {
-      return undefined;
-    }
-    const decodedToken: { [key: string]: ClaimToken } = {};
-    for (let token in vc) {
-      const claimToken = ClaimToken.create(vc[token]);
-      decodedToken[this.id] = claimToken;
-    }
-    return decodedToken;
   }
 }

--- a/lib/options/IValidationOptions.ts
+++ b/lib/options/IValidationOptions.ts
@@ -85,9 +85,4 @@ getTokenObjectDelegate: GetTokenObject;
    * Signature validation
    */
   validateSignatureOnTokenDelegate: ValidateSignatureOnToken,
-
-  /**
-   * Retrieve tokens from SIOP
-   */
-  getTokensFromSiopDelegate: GetTokensFromSiop,
 }

--- a/lib/options/ValidationOptions.ts
+++ b/lib/options/ValidationOptions.ts
@@ -30,7 +30,6 @@ constructor (public validatorOptions: IValidatorOptions, public tokenType: Token
   this.checkScopeValidityOnVcTokenDelegate = this.validationHelpers.checkScopeValidityOnVcToken;
   this.fetchKeyAndValidateSignatureOnIdTokenDelegate = this.validationHelpers.fetchKeyAndValidateSignatureOnIdToken;
   this.validateSignatureOnTokenDelegate = this.validationHelpers.validateSignatureOnToken;
-  this.getTokensFromSiopDelegate = this.validationHelpers.getTokensFromSiop;
 }
 
 /**
@@ -87,9 +86,4 @@ public getTokenObjectDelegate: GetTokenObject;
    * Signature validation
    */
   public validateSignatureOnTokenDelegate: ValidateSignatureOnToken;
-  
-  /**
-   * Retrieve tokens from SIOP
-   */
-  public getTokensFromSiopDelegate: GetTokensFromSiop;
 }

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -57,7 +57,7 @@ describe('PresentationExchange', () => {
             .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
             .build();
         let result = await validator.validate(response.rawToken);
-        expect(result.result).toBeTruthy();
+        expect(result.result).toBeTruthy();        
 
         // Negative cases
 

--- a/tests/SiopValidationSimulation.spec.ts
+++ b/tests/SiopValidationSimulation.spec.ts
@@ -13,21 +13,4 @@ describe('SiopValidationSimulation', () => {
   afterEach(async () => {
     setup.fetchMock.reset();
   });
-  xit('should validate the WoodgroveIdentityCredential', async () =>{
-        // Token to test - WoodgroveIdentityCredential
-        const token = SiopValidationSimulation.token;
-           
-    // Check validator
-    let validator = new ValidatorBuilder(setup.crypto)
-      .useTrustedIssuerConfigurationsForIdTokens(['https://login.microsoftonline.com/woodgrove.ms/.well-known/openid-configuration'])    
-      .useAudienceUrl(SiopValidationSimulation.siopExpected.audience!)
-      .build();
-
-    const queue = new ValidationQueue();
-    queue.enqueueToken('siopPresentationAttestation', token);
-    const result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.result).toBeTruthy();
-
-  });
-
 });

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -28,6 +28,11 @@ describe('Validator', () => {
     //expected.configuration = (<{ [contract: string]: string[]}>expected.configuration)[Validator.getContractIdFromSiop(siop.contract)];
 
     let tokenValidator = new IdTokenTokenValidator(setup.validatorOptions, expected);
+    expect(()=> tokenValidator.getTokens(<any>undefined, <any>undefined)).toThrowError('Not implemented');
+
+    let selfIssuedValidator = new SelfIssuedTokenValidator(setup.validatorOptions, expected);
+    expect(()=> selfIssuedValidator.getTokens(<any>undefined, <any>undefined)).toThrowError('Not implemented');
+
     let validator = new ValidatorBuilder(crypto)
       .useValidators(tokenValidator)
       .useTrustedIssuerConfigurationsForIdTokens([setup.defaultIdTokenConfiguration])
@@ -71,6 +76,8 @@ describe('Validator', () => {
     const expected: any = siop.expected.filter((token: IExpectedVerifiableCredential) => token.type === TokenType.verifiableCredential)[0];
 
     const tokenValidator = new VerifiableCredentialTokenValidator(setup.validatorOptions, expected);
+    expect(()=> tokenValidator.getTokens(<any>undefined, <any>undefined)).toThrowError('Not implemented');
+
     const validator = new ValidatorBuilder(crypto)
       .useValidators(tokenValidator)
       .build();
@@ -80,7 +87,7 @@ describe('Validator', () => {
   
   });
 
-  it('should validate verifiable presentations', async () => {
+  fit('should validate verifiable presentations', async () => {
     const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.verifiablePresentation, true);
     const vcExpected: IExpectedVerifiableCredential = siop.expected.filter((token: IExpectedVerifiableCredential) => token.type === TokenType.verifiableCredential)[0];
     const vpExpected: IExpectedVerifiablePresentation = siop.expected.filter((token: IExpectedVerifiablePresentation) => token.type === TokenType.verifiablePresentation)[0];

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -112,20 +112,20 @@ describe('Validator', () => {
 
     // Check VP validator
     let queue = new ValidationQueue();
-    queue.enqueueToken('vp', siop.vp.rawToken);
+    queue.enqueueToken('vp', siop.vp);
     let result = await vpValidator.validate(queue, queue.getNextToken()!, setup.defaultUserDid);
     expect(result.result).toBeTruthy('vpValidator succeeded');
     expect(result.tokensToValidate![`DrivingLicense`].rawToken).toEqual(siop.vc.rawToken);
 
     // Check VC validator
     queue = new ValidationQueue();
-    queue.enqueueToken(vcAttestationName, siop.vc.rawToken);
+    queue.enqueueToken(vcAttestationName, siop.vc);
     result = await vcValidator.validate(queue, queue.getNextToken()!, setup.defaultUserDid);
     expect(result.result).toBeTruthy('vcValidator succeeded');
 
     // Check validator
     queue = new ValidationQueue();
-    queue.enqueueToken('vp', siop.vp.rawToken);
+    queue.enqueueToken('vp', siop.vp);
     result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeTruthy('check validator');
     expect(result.validationResult?.verifiableCredentials).toBeDefined();
@@ -136,7 +136,7 @@ describe('Validator', () => {
       .useValidators([])
       .build();
     queue = new ValidationQueue();
-    queue.enqueueToken('vp', siop.vp.rawToken);
+    queue.enqueueToken('vp', siop.vp);
     result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeFalsy();
     expect(result.detailedError).toEqual('verifiablePresentation does not has a TokenValidator');
@@ -147,7 +147,7 @@ describe('Validator', () => {
       .enableFeatureVerifiedCredentialsStatusCheck(false)
       .build();
     queue = new ValidationQueue();
-    queue.enqueueToken('vp', siop.vp.rawToken);
+    queue.enqueueToken('vp', siop.vp);
     result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeFalsy();
     expect(result.detailedError).toEqual('verifiableCredential does not has a TokenValidator');

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -87,7 +87,7 @@ describe('Validator', () => {
   
   });
 
-  fit('should validate verifiable presentations', async () => {
+  it('should validate verifiable presentations', async () => {
     const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.verifiablePresentation, true);
     const vcExpected: IExpectedVerifiableCredential = siop.expected.filter((token: IExpectedVerifiableCredential) => token.type === TokenType.verifiableCredential)[0];
     const vpExpected: IExpectedVerifiablePresentation = siop.expected.filter((token: IExpectedVerifiablePresentation) => token.type === TokenType.verifiablePresentation)[0];
@@ -115,7 +115,7 @@ describe('Validator', () => {
     queue.enqueueToken('vp', siop.vp.rawToken);
     let result = await vpValidator.validate(queue, queue.getNextToken()!, setup.defaultUserDid);
     expect(result.result).toBeTruthy('vpValidator succeeded');
-    expect(result.tokensToValidate![`vp`].rawToken).toEqual(siop.vc.rawToken);
+    expect(result.tokensToValidate![`DrivingLicense`].rawToken).toEqual(siop.vc.rawToken);
 
     // Check VC validator
     queue = new ValidationQueue();
@@ -169,7 +169,7 @@ describe('Validator', () => {
     expect(validator.builder.audienceUrl).toEqual(siopExpected.audience);
     
     const queue = new ValidationQueue();
-    queue.enqueueToken('siopPresentationAttestation', request.rawToken);
+    queue.enqueueToken('siopPresentationAttestation', request);
     let result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeTruthy();
     expect(result.status).toEqual(200);
@@ -187,7 +187,7 @@ describe('Validator', () => {
     // Negative cases
     // map issuer to other credential type
     validator = validator.builder.useTrustedIssuersForVerifiableCredentials({ someCredential: vcExpected.contractIssuers.DrivingLicense }).build();
-    queue.enqueueToken('siopPresentationAttestation', request.rawToken);
+    queue.enqueueToken('siopPresentationAttestation', request);
     result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeFalsy();
     expect(result.detailedError).toEqual(`Expected should have contractIssuers set for verifiableCredential. Missing contractIssuers for 'DrivingLicense'.`);
@@ -216,7 +216,7 @@ describe('Validator', () => {
     expect(validator.resolver).toBeDefined();
     
     const queue = new ValidationQueue();
-    queue.enqueueToken('siop', request.rawToken);
+    queue.enqueueToken('siop', request);
     const result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeTruthy();
     expect(result.status).toEqual(200);
@@ -259,7 +259,7 @@ describe('Validator', () => {
     
     const queue = new ValidationQueue();
     const ct = ClaimToken.create(request.rawToken);
-    queue.enqueueToken('siop', ct.rawToken);
+    queue.enqueueToken('siop', ct);
     const result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeTruthy();
     expect(result.status).toEqual(200);


### PR DESCRIPTION
**Problem:**
Some applications want to use SiopValidator without fetching the tokens in the SIOP


**Solution:**
SiopValidator is not retrieving tokens. This is done in SiopTokenValidator which puts the tokens in the queue.
The pattern is normalized for the other validators.
An optimization feature to accept ClaimToken as input in Validator.validator.


**Validation:**
Updated unit tests


**Type of change:**
- [ x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

