### PR TITLE
Beejones/add remote key reference

### DIFF
--- a/lib/api_oidc_request/Requestor.ts
+++ b/lib/api_oidc_request/Requestor.ts
@@ -80,11 +80,11 @@ export default class Requestor {
 
     const key = crypto.signingKeyReference;
     const signature = await this.builder.signingProtocol.sign(Buffer.from(JSON.stringify(this._payload)));
-
+    const token = await signature.serialize();
     const response = {
       result: true,
       status: 200,
-      request: signature.serialize()
+      request: token
     };
 
     return response;

--- a/lib/api_oidc_request/Requestor.ts
+++ b/lib/api_oidc_request/Requestor.ts
@@ -79,7 +79,7 @@ export default class Requestor {
       this.createPresentationExchangeRequest(this._payload);
 
     const key = crypto.signingKeyReference;
-    const signature = await this.builder.signingProtocol.sign(Buffer.from(JSON.stringify(this._payload)));
+    const signature = await this.builder.signingProtocol.sign(this._payload);
     const token = await signature.serialize();
     const response = {
       result: true,

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -291,7 +291,7 @@ export default class Validator {
         if (statusUrl) {
           // send the payload
           payload.aud = statusUrl;
-          const siop = await this.builder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(payload)));
+          const siop = await this.builder.crypto.signingProtocol.sign(payload);
           const serialized = await siop.serialize();
 
           console.log(`verifiablePresentation status check on ${statusUrl} ====> ${serialized}`);

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -292,7 +292,7 @@ export default class Validator {
           // send the payload
           payload.aud = statusUrl;
           const siop = await this.builder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(payload)));
-          const serialized = siop.serialize();
+          const serialized = await siop.serialize();
 
           console.log(`verifiablePresentation status check on ${statusUrl} ====> ${serialized}`);
           let response = await fetch(statusUrl, {

--- a/lib/input_validation/BaseIdTokenValidation.ts
+++ b/lib/input_validation/BaseIdTokenValidation.ts
@@ -31,7 +31,7 @@ export abstract class BaseIdTokenValidation implements IIdTokenValidation {
     };
 
     // Deserialize id token token
-    validationResponse = this.options.getTokenObjectDelegate(validationResponse, idToken);
+    validationResponse = await this.options.getTokenObjectDelegate(validationResponse, idToken);
     if (!validationResponse.result) {
       return validationResponse;
     }

--- a/lib/input_validation/DidValidation.ts
+++ b/lib/input_validation/DidValidation.ts
@@ -33,7 +33,7 @@ export class DidValidation implements IDidValidation {
     };
 
     // Deserialize the token
-    validationResponse = this.options.getTokenObjectDelegate(validationResponse, token);
+    validationResponse = await this.options.getTokenObjectDelegate(validationResponse, token);
     if (!validationResponse.result) {
       return validationResponse;
     }

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -42,11 +42,11 @@ export class ValidationHelpers {
    * @returns validationResponse.did The DID used to sign the token
    * @returns validationResponse.payloadObject The parsed payload
    */
-  public getTokenObject(validationResponse: IValidationResponse, token: string): IValidationResponse {
+  public async getTokenObject(validationResponse: IValidationResponse, token: string): Promise<IValidationResponse> {
     let tokenPayload: Buffer;
     const self: any = this;
     try {
-      validationResponse.didSignature = (self as ValidationOptions).validatorOptions.crypto.signingProtocol.deserialize(token);
+      validationResponse.didSignature = await (self as ValidationOptions).validatorOptions.crypto.signingProtocol.deserialize(token);
       if (!validationResponse.didSignature) {
         return {
           result: false,
@@ -562,7 +562,7 @@ export class ValidationHelpers {
     const self: any = this;
     try {
       // Get token and check signature
-      validationResponse = (self as IValidationOptions).getTokenObjectDelegate(validationResponse, token.rawToken);
+      validationResponse = await (self as IValidationOptions).getTokenObjectDelegate(validationResponse, token.rawToken);
       const validation = await (self as ValidationOptions).validatorOptions.crypto.signingProtocol.verify([key]);
       if (!validation) {
         return {

--- a/lib/options/IValidationOptions.ts
+++ b/lib/options/IValidationOptions.ts
@@ -9,7 +9,7 @@ import { ValidationHelpers } from '../input_validation/ValidationHelpers';
 import IValidatorOptions from './IValidatorOptions';
 import { IExpectedBase, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedAudience } from './IExpected';
 
- export type GetTokenObject = (validationResponse: IValidationResponse, token: string) => IValidationResponse;
+ export type GetTokenObject = (validationResponse: IValidationResponse, token: string) => Promise<IValidationResponse>;
  export type ResolveDidAndGetKeys = (validationResponse: IValidationResponse) => Promise<IValidationResponse>;
  export type ValidateDidSignature = (validationResponse: IValidationResponse, token: IPayloadProtectionSigning) => Promise<IValidationResponse>;
  export type CheckTimeValidityOnIdToken = (validationResponse: IValidationResponse, driftInSec?: number) => IValidationResponse;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jsonpath": "1.0.2",
     "multihashes": "0.4.14",
     "uuid": "7.0.1",
-    "verifiablecredentials-crypto-sdk-typescript": "1.1.11-preview.3"
+    "verifiablecredentials-crypto-sdk-typescript": "1.1.11-preview.5"
   },
   "nyc": {
     "extension": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.10.1-preview.3",
+  "version": "0.10.1-preview.5",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/IssuanceHelpers.ts
+++ b/tests/IssuanceHelpers.ts
@@ -189,7 +189,7 @@ export class IssuanceHelpers {
     setup.validatorOptions.crypto.builder.useSigningKeyReference(keyId);
     setup.validatorOptions.crypto.signingProtocol.builder.useKid(keyId.keyReference);
     const signature = await setup.validatorOptions.crypto.signingProtocol.sign(Buffer.from(payload));
-    const token = setup.validatorOptions.crypto.signingProtocol.serialize();
+    const token = await setup.validatorOptions.crypto.signingProtocol.serialize();
     let claimToken = new ClaimToken(TokenType.idToken, token, configuration);
     return claimToken;
   }

--- a/tests/IssuanceHelpers.ts
+++ b/tests/IssuanceHelpers.ts
@@ -19,7 +19,7 @@ export class IssuanceHelpers {
    * Create siop request
    */
   public static async createSiopRequestWithPayload(setup: TestSetup, siop: any, key: any): Promise<ClaimToken> {
-    const claimToken = await IssuanceHelpers.signAToken(setup, JSON.stringify(siop), '', key);
+    const claimToken = await IssuanceHelpers.signAToken(setup, siop, '', key);
     return claimToken;
   }
 
@@ -87,7 +87,7 @@ export class IssuanceHelpers {
       sub: `${setup.defaultUserDid}`
     };
     vcTemplate.vc.credentialSubject = credentialSubject;
-    return IssuanceHelpers.signAToken(setup, JSON.stringify(vcTemplate), configuration, jwkPrivate);
+    return IssuanceHelpers.signAToken(setup, vcTemplate, configuration, jwkPrivate);
   }
 
   /**
@@ -114,7 +114,7 @@ export class IssuanceHelpers {
     for (let inx = 0; inx < vcs.length; inx++) {
       (vpTemplate.vp.verifiableCredential as string[]).push(vcs[inx].rawToken);
     }
-    return IssuanceHelpers.signAToken(setup, JSON.stringify(vpTemplate), '', jwkPrivate);
+    return IssuanceHelpers.signAToken(setup, vpTemplate, '', jwkPrivate);
   }
 
   /**
@@ -183,12 +183,12 @@ export class IssuanceHelpers {
   }
 
   // Sign a token
-  public static async signAToken(setup: TestSetup, payload: string, configuration: string, jwkPrivate: any): Promise<ClaimToken> {
+  public static async signAToken(setup: TestSetup, payload: object, configuration: string, jwkPrivate: any): Promise<ClaimToken> {
     const keyId = new KeyReference(jwkPrivate.kid);
     await setup.keyStore.save(keyId, <any>jwkPrivate);
     setup.validatorOptions.crypto.builder.useSigningKeyReference(keyId);
     setup.validatorOptions.crypto.signingProtocol.builder.useKid(keyId.keyReference);
-    const signature = await setup.validatorOptions.crypto.signingProtocol.sign(Buffer.from(payload));
+    const signature = await setup.validatorOptions.crypto.signingProtocol.sign(payload);
     const token = await setup.validatorOptions.crypto.signingProtocol.serialize();
     let claimToken = new ClaimToken(TokenType.idToken, token, configuration);
     return claimToken;
@@ -216,7 +216,7 @@ export class IssuanceHelpers {
 
     const idToken = await IssuanceHelpers.signAToken(
       setup,
-      JSON.stringify(idTokenPayload),
+      idTokenPayload,
       tokenConfiguration,
       tokenJwkPrivate);
 

--- a/tests/KeyvaultTest.spec.ts
+++ b/tests/KeyvaultTest.spec.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import Credentials from './Credentials';
+import { ClientSecretCredential } from '@azure/identity';
+import { CryptoBuilder, JoseBuilder, KeyReference } from '../lib';
+
+describe('Sample for Requestor with different key type and using Key Vault', () =>{
+  const credentials = new ClientSecretCredential(Credentials.tenantGuid, Credentials.clientId, Credentials.clientSecret);
+  const keyVaultEnabled = Credentials.vaultUri.startsWith('https');
+  if(keyVaultEnabled) {
+    console.log('To run this sample, you must specify your Key Vault credentials in Credentials.ts');
+    return;
+  }
+  let originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+  beforeAll(async () => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;            
+  });
+  afterAll(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
+
+  it('should sign on key vault', async () => {
+    const kvSigningKey = 'EC-Key-for-testing-remote-reference';
+    const kvRecoveryKey = 'EC-Key-for-testing-remote-reference-recovery';
+    const signingKeyReference = new KeyReference(kvSigningKey);
+    const recoveryKeyReference = new KeyReference(kvRecoveryKey);
+    let cryptoKv = new CryptoBuilder()
+        .useSigningKeyReference(signingKeyReference)
+        .useRecoveryKeyReference(recoveryKeyReference)
+        .useKeyVault(credentials, Credentials.vaultUri)
+        .build();
+
+    // Create request
+    const payload = {
+      purpose: 'payload to sign',
+      action: 'make key vault swing'
+    };
+
+    const jose = new JoseBuilder(cryptoKv).build();
+    //jose = await jose
+  });
+
+});

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -45,7 +45,7 @@ describe('PresentationExchange', () => {
         console.log(request.rawToken);
     });
 
-    it('should create a response and validate', async () => {
+    fit('should create a response and validate', async () => {
 
         const request: any = await requestor.createPresentationExchangeRequest();
         expect(request.rawToken).toBeDefined();

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -45,7 +45,7 @@ describe('PresentationExchange', () => {
         console.log(request.rawToken);
     });
 
-    fit('should create a response and validate', async () => {
+    it('should create a response and validate', async () => {
 
         const request: any = await requestor.createPresentationExchangeRequest();
         expect(request.rawToken).toBeDefined();
@@ -64,7 +64,7 @@ describe('PresentationExchange', () => {
         //Remove presentation_submission
         let responsePayload = clone(response.decodedToken);
         delete responsePayload.presentation_submission;
-        let siop = await (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
+        let siop = await (await responder.crypto.signingProtocol.sign(responsePayload)).serialize();
         result = await validator.validate(siop);
         expect(result.result).toBeFalsy();
         expect(result.detailedError).toEqual('SIOP was not recognized.');
@@ -72,7 +72,7 @@ describe('PresentationExchange', () => {
         //Remove tokens
         responsePayload = clone(response.decodedToken);
         delete responsePayload.presentation_submission.attestations;
-        siop = await (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
+        siop = await (await responder.crypto.signingProtocol.sign(responsePayload)).serialize();
         result = await validator.validate(siop);
         expect(result.result).toBeFalsy();
         expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
@@ -80,7 +80,7 @@ describe('PresentationExchange', () => {
         //Remove path
         responsePayload = clone(response.decodedToken);
         delete responsePayload.presentation_submission.descriptor_map[0].path;
-        siop = await (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
+        siop = await (await responder.crypto.signingProtocol.sign(responsePayload)).serialize();
         result = await validator.validate(siop);
         expect(result.result).toBeFalsy();
         expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -64,7 +64,7 @@ describe('PresentationExchange', () => {
         //Remove presentation_submission
         let responsePayload = clone(response.decodedToken);
         delete responsePayload.presentation_submission;
-        let siop = (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
+        let siop = await (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
         result = await validator.validate(siop);
         expect(result.result).toBeFalsy();
         expect(result.detailedError).toEqual('SIOP was not recognized.');
@@ -72,7 +72,7 @@ describe('PresentationExchange', () => {
         //Remove tokens
         responsePayload = clone(response.decodedToken);
         delete responsePayload.presentation_submission.attestations;
-        siop = (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
+        siop = await (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
         result = await validator.validate(siop);
         expect(result.result).toBeFalsy();
         expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
@@ -80,7 +80,7 @@ describe('PresentationExchange', () => {
         //Remove path
         responsePayload = clone(response.decodedToken);
         delete responsePayload.presentation_submission.descriptor_map[0].path;
-        siop = (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
+        siop = await (await responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(responsePayload)))).serialize();
         result = await validator.validate(siop);
         expect(result.result).toBeFalsy();
         expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);

--- a/tests/ResponderHelper.ts
+++ b/tests/ResponderHelper.ts
@@ -29,7 +29,7 @@ export default class ResponderHelper {
     public async setup(): Promise<void> {
         this.crypto = await this.crypto.generateKey(KeyUse.Signature, 'signing');
         this.crypto = await this.crypto.generateKey(KeyUse.Signature, 'recovery');
-        let did = await new LongFormDid(this.crypto).serialize();
+        let did = await (new LongFormDid(this.crypto)).serialize();
         this.crypto.builder.useDid(did);
 
         // setup mock so requestor can resolve this did
@@ -67,7 +67,7 @@ export default class ResponderHelper {
 
                 // Sign the receipts
                 await this.generator.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(this.responseDefinition.responseStatus[presentation])));
-                statusReceipts.receipt[jti] = this.generator.crypto.signingProtocol.serialize();
+                statusReceipts.receipt[jti] = await this.generator.crypto.signingProtocol.serialize();
 
                 const statusUrl = vcs.decodedToken.vc.credentialStatus.id;
                 TokenGenerator.fetchMock.post(statusUrl, statusReceipts, { overwriteRoutes: true });
@@ -90,7 +90,7 @@ export default class ResponderHelper {
 
                 // Sign
                 await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(vpPayload)));
-                presentations[presentation] = this.crypto.signingProtocol.serialize();
+                presentations[presentation] = await this.crypto.signingProtocol.serialize();
             }
         }
 
@@ -107,7 +107,7 @@ export default class ResponderHelper {
             }
         }
 
-        const token = (await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(payload)))).serialize();
+        const token = await (await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(payload)))).serialize();
         return new ClaimToken(TokenType.siopPresentationAttestation, token);
     }
 

--- a/tests/ResponderHelper.ts
+++ b/tests/ResponderHelper.ts
@@ -66,7 +66,7 @@ export default class ResponderHelper {
                 this.responseDefinition.responseStatus[presentation].iss = this.generator.crypto.builder.did;
 
                 // Sign the receipts
-                await this.generator.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(this.responseDefinition.responseStatus[presentation])));
+                await this.generator.crypto.signingProtocol.sign(this.responseDefinition.responseStatus[presentation]);
                 statusReceipts.receipt[jti] = await this.generator.crypto.signingProtocol.serialize();
 
                 const statusUrl = vcs.decodedToken.vc.credentialStatus.id;
@@ -89,7 +89,7 @@ export default class ResponderHelper {
                 }
 
                 // Sign
-                await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(vpPayload)));
+                await this.crypto.signingProtocol.sign(vpPayload);
                 presentations[presentation] = await this.crypto.signingProtocol.serialize();
             }
         }
@@ -107,7 +107,7 @@ export default class ResponderHelper {
             }
         }
 
-        const token = await (await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(payload)))).serialize();
+        const token = await (await this.crypto.signingProtocol.sign(payload)).serialize();
         return new ClaimToken(TokenType.siopPresentationAttestation, token);
     }
 

--- a/tests/TokenGenerator.ts
+++ b/tests/TokenGenerator.ts
@@ -98,7 +98,7 @@ export default class TokenGenerator {
 
                 // Sign
                 await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(payload)));
-                idTokens[configuration] = this.crypto.signingProtocol.serialize();
+                idTokens[configuration] = await this.crypto.signingProtocol.serialize();
             }
         }
     }
@@ -111,8 +111,9 @@ export default class TokenGenerator {
         vcPayload.iss = `${this.crypto.builder.did}`;
 
         // Sign
-        await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(vcPayload)));
-        return ClaimToken.create(this.crypto.signingProtocol.serialize());
+        await this.crypto.signingProtocol.sign(vcPayload);
+        const token = await this.crypto.signingProtocol.serialize();
+        return ClaimToken.create(token);
     }
 
     public async setVcsInPresentations(): Promise<void> {
@@ -143,7 +144,7 @@ export default class TokenGenerator {
         for (let inx = 0; inx < vc.length; inx++) {
             (vpTemplate.vp.verifiableCredential as string[]).push(vc[inx].rawToken);
         }
-        const token = (await this.responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(vpTemplate)))).serialize();
+        const token = await (await this.responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(vpTemplate)))).serialize();
         return new ClaimToken(TokenType.verifiablePresentation, token, '');
     }
 }

--- a/tests/TokenGenerator.ts
+++ b/tests/TokenGenerator.ts
@@ -97,7 +97,7 @@ export default class TokenGenerator {
                 payload.iss = `${this.crypto.builder.did}`;
 
                 // Sign
-                await this.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(payload)));
+                await this.crypto.signingProtocol.sign(payload);
                 idTokens[configuration] = await this.crypto.signingProtocol.serialize();
             }
         }
@@ -144,7 +144,7 @@ export default class TokenGenerator {
         for (let inx = 0; inx < vc.length; inx++) {
             (vpTemplate.vp.verifiableCredential as string[]).push(vc[inx].rawToken);
         }
-        const token = await (await this.responder.crypto.signingProtocol.sign(Buffer.from(JSON.stringify(vpTemplate)))).serialize();
+        const token = await (await this.responder.crypto.signingProtocol.sign(vpTemplate)).serialize();
         return new ClaimToken(TokenType.verifiablePresentation, token, '');
     }
 }

--- a/tests/ValidationHelpers.spec.ts
+++ b/tests/ValidationHelpers.spec.ts
@@ -257,7 +257,7 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
         jti: 'jti'
       };
 
-      const idToken = await IssuanceHelpers.signAToken(setup, JSON.stringify(payload), tokenConfiguration, tokenJwkPrivate);
+      const idToken = await IssuanceHelpers.signAToken(setup, payload, tokenConfiguration, tokenJwkPrivate);
 
       let response = await options.fetchKeyAndValidateSignatureOnIdTokenDelegate(validationResponse, idToken);
       expect(response.result).toBeTruthy();

--- a/tests/ValidationHelpers.spec.ts
+++ b/tests/ValidationHelpers.spec.ts
@@ -27,14 +27,14 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
       status: 200,
       result: true
     }
-    let response = options.getTokenObjectDelegate(validationResponse, request.rawToken);
+    let response = await options.getTokenObjectDelegate(validationResponse, request.rawToken);
     expect(response.result).toBeTruthy();
     expect(response.status).toEqual(200);    
 
     // negative cases
     // malformed token
     let splitToken = request.rawToken.split('.');
-    response = options.getTokenObjectDelegate(validationResponse, splitToken[0]);
+    response = await options.getTokenObjectDelegate(validationResponse, splitToken[0]);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(400);    
     expect(response.detailedError).toEqual('The verifiableCredential could not be deserialized');
@@ -42,7 +42,7 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
     // missing kid
     const header: any = JSON.parse(base64url.decode(splitToken[0]));
     header.kid = '';
-    response = options.getTokenObjectDelegate(validationResponse, `${base64url.encode(JSON.stringify(header))}.${splitToken[1]}.${splitToken[2]}`);
+    response = await options.getTokenObjectDelegate(validationResponse, `${base64url.encode(JSON.stringify(header))}.${splitToken[1]}.${splitToken[2]}`);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);    
     expect(response.detailedError).toEqual('The protected header in the verifiableCredential does not contain the kid');
@@ -104,7 +104,7 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
       result: true,
       did: setup.defaultUserDid
     };
-    validationResponse = options.getTokenObjectDelegate(validationResponse, request.rawToken);
+    validationResponse = await options.getTokenObjectDelegate(validationResponse, request.rawToken);
     validationResponse.didSigningPublicKey = siopRequest.didJwkPublic;
     const token = validationResponse.didSignature as IPayloadProtectionSigning;
     let response = await options.validateDidSignatureDelegate(validationResponse, token);
@@ -113,7 +113,7 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
     
     // negative cases
     // Bad signature
-    validationResponse = options.getTokenObjectDelegate(validationResponse, request.rawToken + 1);    
+    validationResponse = await options.getTokenObjectDelegate(validationResponse, request.rawToken + 1);    
     response = await options.validateDidSignatureDelegate(validationResponse, validationResponse.didSignature as IPayloadProtectionSigning);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403); 
@@ -121,21 +121,21 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
 
     // No signature
     const splitToken = request.rawToken.split('.');
-    validationResponse = options.getTokenObjectDelegate(validationResponse, `${splitToken[0]}.${splitToken[1]}`);    
+    validationResponse = await options.getTokenObjectDelegate(validationResponse, `${splitToken[0]}.${splitToken[1]}`);    
     response = await options.validateDidSignatureDelegate(validationResponse, validationResponse.didSignature as IPayloadProtectionSigning);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403); 
     expect(response.detailedError).toEqual('The signature on the payload in the verifiableCredential is invalid');
 
     // no header
-    validationResponse = options.getTokenObjectDelegate(validationResponse, `.${splitToken[1]}.${splitToken[2]}`);    
+    validationResponse = await options.getTokenObjectDelegate(validationResponse, `.${splitToken[1]}.${splitToken[2]}`);    
     response = await options.validateDidSignatureDelegate(validationResponse, validationResponse.didSignature as IPayloadProtectionSigning);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403); 
     expect(response.detailedError).toEqual('Failed to validate signature');
 
     // no payload
-    validationResponse = options.getTokenObjectDelegate(validationResponse, `${splitToken[0]}..${splitToken[2]}`);    
+    validationResponse = await options.getTokenObjectDelegate(validationResponse, `${splitToken[0]}..${splitToken[2]}`);    
     response = await options.validateDidSignatureDelegate(validationResponse, validationResponse.didSignature as IPayloadProtectionSigning);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403); 

--- a/tests/models/RequestOneVcResponseOk.ts
+++ b/tests/models/RequestOneVcResponseOk.ts
@@ -6,7 +6,7 @@ import ITestModel from "./ITestModel";
 import { ClaimToken, TokenType } from "../../lib";
 
 
-export default class RequestOnceVcResponseOk implements ITestModel {
+export default class RequestOneVcResponseOk implements ITestModel {
     public clientId = 'https://requestor.example.com';
 
     /**


### PR DESCRIPTION
**Problem:**
Optionally the key id on the DID document can differ from the key id in key vault. For this a remote key reference is added to KeyReference.
The kid on the signature is the id of the DID document by default
The signers all have async methods for serialize and deserialize.
The sign method is defaulting to passing in an object. So no more Buffer.from(JSON.stringify....

**Validation:**
Unit tests

**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

