### PR TITLE
OIDC request should have id_token as response_type

### DIFF
--- a/lib/api_oidc_request/Requestor.ts
+++ b/lib/api_oidc_request/Requestor.ts
@@ -43,7 +43,7 @@ export default class Requestor {
   public async create(state?: string, nonce?: string): Promise<IRequestorResult> {
     const crypto = this.builder.crypto.builder;
     this._payload = {
-      response_type: 'idtoken',
+      response_type: 'id_token',
       response_mode: 'form_post',
       client_id: this.builder.clientId,
       redirect_uri: this.builder.redirectUri,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.10.1-preview.9",
+  "version": "0.10.1-preview.10",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/Requestor.spec.ts
+++ b/tests/Requestor.spec.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { KeyUse, RequestorBuilder } from '../lib';
+import PresentationDefinition from './models/PresentationDefinitionSample1'
+
+describe('Requestor', () =>{
+  it('should create a requestor', async () => {
+    const requestor = new RequestorBuilder(PresentationDefinition.presentationExchangeDefinition)
+      .build();
+
+    // Generate key
+    await requestor.builder.crypto.generateKey(KeyUse.Signature);
+    const request = await requestor.create();
+    expect(request.result).toBeTruthy();
+    expect(requestor.payload.response_type).toEqual('id_token');
+    expect(requestor.payload.scope).toEqual('openid did_authn');
+    expect(requestor.payload.response_mode).toEqual('form_post');
+    expect(requestor.payload.client_id).toEqual('https://response.example.com');
+    expect(requestor.payload.redirect_uri).toEqual('https://response.example.com');
+  });
+});

--- a/tests/Requestor.spec.ts
+++ b/tests/Requestor.spec.ts
@@ -17,7 +17,7 @@ describe('Requestor', () =>{
     expect(requestor.payload.response_type).toEqual('id_token');
     expect(requestor.payload.scope).toEqual('openid did_authn');
     expect(requestor.payload.response_mode).toEqual('form_post');
-    expect(requestor.payload.client_id).toEqual('https://response.example.com');
+    expect(requestor.payload.client_id).toEqual('https://requestor.example.com');
     expect(requestor.payload.redirect_uri).toEqual('https://response.example.com');
   });
 });


### PR DESCRIPTION
**Problem:**
The OIDC request had idtoken as response_type, should be id_token


**Solution:**
Fixed value

**Validation:**
Check by unit tests


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
