### PR TITLE
 change the value of client_id to equal redirect_uri

### DIFF
--- a/lib/api_oidc_request/Requestor.ts
+++ b/lib/api_oidc_request/Requestor.ts
@@ -45,7 +45,7 @@ export default class Requestor {
     this._payload = {
       response_type: 'id_token',
       response_mode: 'form_post',
-      client_id: this.builder.clientId,
+      client_id: this.builder.redirectUri,
       redirect_uri: this.builder.redirectUri,
       scope: 'openid did_authn',
       state: state || this.builder.state,
@@ -145,19 +145,20 @@ export default class Requestor {
     const issuers: { [credentialType: string]: string[] } = {};
 
     if (this.isPresentationExchange()) {
-      return { undefined: [] };
-
       /*
-      // const presentationDefinition = (<IRequestorPresentationExchange>this.builder.requestor).presentationDefinition;
+      const presentationDefinition = (<IRequestorPresentationExchange>this.builder.requestor).presentationDefinition;
       if (!presentationDefinition.input_descriptors) {
         return { undefined: [] };
       }
+      const issuers: { [credentialType: string]: string[] } = {};
       for (let definition in presentationDefinition.input_descriptors) {
         if (!presentationDefinition.input_descriptors[definition]) {
           throw new Error('Missing id in input_descriptor');
         }
+      }
+      return issuers;
       */
-
+     throw new Error('trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.')
     } else {
       const attestations = (<IRequestorAttestation>this.builder.requestor).attestations;
       if (!attestations.presentations) {

--- a/tests/Requestor.spec.ts
+++ b/tests/Requestor.spec.ts
@@ -17,7 +17,16 @@ describe('Requestor', () =>{
     expect(requestor.payload.response_type).toEqual('id_token');
     expect(requestor.payload.scope).toEqual('openid did_authn');
     expect(requestor.payload.response_mode).toEqual('form_post');
-    expect(requestor.payload.client_id).toEqual('https://requestor.example.com');
+    expect(requestor.payload.client_id).toEqual('https://response.example.com');
     expect(requestor.payload.redirect_uri).toEqual('https://response.example.com');
+    expect(requestor.audienceUrl()).toEqual('https://response.example.com');
+    
   });
+  it('should return trusted issuers', () => {
+    const requestor = new RequestorBuilder(PresentationDefinition.presentationExchangeDefinition)
+      .build();
+
+      expect(() => requestor.trustedIssuerConfigurationsForIdTokens()).toThrowError('Id Tokens only supported in Attestation Requestor model.');
+      expect(() => requestor.trustedIssuersForVerifiableCredentials()).toThrowError('trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.');
+    })
 });

--- a/tests/ValidatorBuilder.spec.ts
+++ b/tests/ValidatorBuilder.spec.ts
@@ -34,14 +34,9 @@ describe('ValidatorBuilder', () => {
 
     let requestor = new RequestorBuilder(<any>{})
       .useState('abcdef');
-      builder = new ValidatorBuilder(crypto)
-      .useState('12345')
-      .useRequestor(requestor.build());
-    expect(builder.state).toEqual('12345');
-
     builder = new ValidatorBuilder(crypto)
-      .useRequestor(requestor.build());
-    expect(builder.state).toEqual('abcdef');
+      .useState('12345');
+    expect(builder.state).toEqual('12345');
   });
 
   it('should set nonce', () => {
@@ -55,14 +50,9 @@ describe('ValidatorBuilder', () => {
 
     let requestor = new RequestorBuilder(<any>{})
       .useNonce('abcdef');
-      builder = new ValidatorBuilder(crypto)
-      .useNonce('12345')
-      .useRequestor(requestor.build());
-    expect(builder.nonce).toEqual('12345');
-
     builder = new ValidatorBuilder(crypto)
-      .useRequestor(requestor.build());
-    expect(builder.nonce).toEqual('abcdef');
+      .useNonce('12345')
+    expect(builder.nonce).toEqual('12345');
   });
 
 });


### PR DESCRIPTION
**Problem:**
 change the value of client_id to equal redirect_uri, so redirect_uri is enforced in Requestor.

**Solution:**
Use redirect_uri in create for client_id


**Validation:**
New unit tests


**Type of change:**
- [ x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

