### PR TITLE
Index Claim Implementation Changes + Bug Fixes

### DIFF
--- a/lib/error_handling/RulesValidationError.ts
+++ b/lib/error_handling/RulesValidationError.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Typed error for rules validation failures.
+ */
+export class RulesValidationError extends Error {}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,6 +8,9 @@ export { DidDocument, IDidDocument, IDidDocumentPublicKey, IDidDocumentServiceDe
 import {IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSelfIssued, IExpectedIdToken, IExpectedOpenIdToken, IExpectedAudience, IssuerMap} from './options/IExpected';
 export { IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSelfIssued, IExpectedIdToken, IExpectedOpenIdToken, IExpectedAudience, IssuerMap };
 
+import { RulesValidationError } from './error_handling/RulesValidationError';
+export { RulesValidationError };
+
 import ManagedHttpResolver from './resolver/ManagedHttpResolver';
 export { ManagedHttpResolver };
 

--- a/lib/input_validation/VerifiableCredentialValidation.ts
+++ b/lib/input_validation/VerifiableCredentialValidation.ts
@@ -41,9 +41,8 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
     }
 
     const isJwt = typeof verifiableCredential === 'string';
-    let sub: string | undefined;
     if (isJwt) {
-      sub = validationResponse.payloadObject.sub;
+      validationResponse.subject = validationResponse.payloadObject.sub;
       if (!validationResponse.payloadObject.vc) {
         return {
           result: false,
@@ -95,7 +94,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
 
     if (isJwt) {
       // Check token sub
-      if (!sub) {
+      if (!validationResponse.subject) {
         return {
           result: false,
           detailedError: `Missing sub property in verifiableCredential. Expected '${siopDid}'`,
@@ -104,7 +103,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       }
 
       // check sub value
-      if (siopDid && sub !== siopDid) {
+      if (siopDid && validationResponse.subject !== siopDid) {
         return {
           result: false,
           detailedError: `Wrong sub property in verifiableCredential. Expected '${siopDid}'`,

--- a/lib/input_validation/VerifiableCredentialValidation.ts
+++ b/lib/input_validation/VerifiableCredentialValidation.ts
@@ -41,8 +41,9 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
     }
 
     const isJwt = typeof verifiableCredential === 'string';
+    let sub: string | undefined;
     if (isJwt) {
-      validationResponse.subject = validationResponse.payloadObject.sub;
+      sub = validationResponse.payloadObject.sub;
       if (!validationResponse.payloadObject.vc) {
         return {
           result: false,
@@ -94,7 +95,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
 
     if (isJwt) {
       // Check token sub
-      if (!validationResponse.subject) {
+      if (!sub) {
         return {
           result: false,
           detailedError: `Missing sub property in verifiableCredential. Expected '${siopDid}'`,
@@ -103,12 +104,17 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       }
 
       // check sub value
-      if (siopDid && validationResponse.subject !== siopDid) {
+      if (siopDid && sub !== siopDid) {
         return {
           result: false,
           detailedError: `Wrong sub property in verifiableCredential. Expected '${siopDid}'`,
           status: 403
         };
+      }
+
+      // make sure the sub claim is the id in the credentialSubject
+      if (!validationResponse.payloadObject.credentialSubject.id) {
+        validationResponse.payloadObject.credentialSubject.id = sub;
       }
     } else {
       let subjects = [];

--- a/lib/input_validation/VerifiableCredentialValidationResponse.ts
+++ b/lib/input_validation/VerifiableCredentialValidationResponse.ts
@@ -6,6 +6,10 @@
 import { IValidationResponse } from './IValidationResponse';
 
 export interface VerifiableCredentialValidationResponse extends IValidationResponse {
+  /**
+   * Verfiable Credential subject DID.
+   */
+  subject?: string;
 }
 
 /**

--- a/lib/input_validation/VerifiableCredentialValidationResponse.ts
+++ b/lib/input_validation/VerifiableCredentialValidationResponse.ts
@@ -6,10 +6,6 @@
 import { IValidationResponse } from './IValidationResponse';
 
 export interface VerifiableCredentialValidationResponse extends IValidationResponse {
-  /**
-   * Verfiable Credential subject DID.
-   */
-  subject?: string;
 }
 
 /**

--- a/lib/rules_model/BaseIssuanceModel.ts
+++ b/lib/rules_model/BaseIssuanceModel.ts
@@ -15,16 +15,18 @@ export abstract class BaseIssuanceModel {
    * @param issuer the DID of the Verifiable Credential Issuer
    * @param attestations IssuanceAttestationsModel instance
    */
-  constructor (public credentialIssuer?: string,  public issuer?: string, public attestations?: IssuanceAttestationsModel) {
-  }
+  constructor (public credentialIssuer?: string,  public issuer?: string, public attestations?: IssuanceAttestationsModel) {}
 
   /**
    * Populate an instance of BaseAttestationModel from any instance
    * @param input object instance to populate from
    */
   populateFrom (input: any): void {
-    this.attestations = new IssuanceAttestationsModel();
-    this.attestations.populateFrom(input.attestations);
+    if (input.attestations) {
+      this.attestations = new IssuanceAttestationsModel();
+      this.attestations.populateFrom(input.attestations);
+    }
+
     this.credentialIssuer = input.credentialIssuer;
     this.issuer = input.issuer;
   }

--- a/lib/rules_model/InputClaimModel.ts
+++ b/lib/rules_model/InputClaimModel.ts
@@ -42,6 +42,7 @@ export class InputClaimModel {
    * Creates an InputClaimInstance for a contract using a subset of properties
    */
   forInput(): InputClaimModel {
-    return new InputClaimModel(this.claim, this.type, this.required);
+    const { claim, indexed, required, type } = this;
+    return new InputClaimModel(claim, type, required, indexed);
   }
 }

--- a/lib/rules_model/InputClaimModel.ts
+++ b/lib/rules_model/InputClaimModel.ts
@@ -42,7 +42,6 @@ export class InputClaimModel {
    * Creates an InputClaimInstance for a contract using a subset of properties
    */
   forInput(): InputClaimModel {
-    const { claim, indexed, required, type } = this;
-    return new InputClaimModel(claim, type, required, indexed);
+    return new InputClaimModel(this.claim, this.type, this.required, this.indexed);
   }
 }

--- a/lib/rules_model/IssuanceAttestationsModel.ts
+++ b/lib/rules_model/IssuanceAttestationsModel.ts
@@ -6,6 +6,7 @@
 import { SelfIssuedAttestationModel } from './SelfIssuedAttestationModel';
 import { VerifiablePresentationAttestationModel } from './VerifiablePresentationAttestationModel';
 import { IdTokenAttestationModel } from './IdTokenAttestationModel';
+import { RulesValidationError } from '../error_handling/RulesValidationError';
 
 /**
  * Model for attestations for input contract
@@ -107,7 +108,7 @@ export class IssuanceAttestationsModel {
 
     // Ensure uniqueness of attestation mapping keys. Non-uniqueness leads to data loss.
     if (totalOutputAttestations !== outputAttestations.size) {
-      throw new Error('Attestation mapping names must be unique.');
+      throw new RulesValidationError('Attestation mapping names must be unique.');
     }
   }
 }

--- a/lib/rules_model/RulesModel.ts
+++ b/lib/rules_model/RulesModel.ts
@@ -59,13 +59,11 @@ export class RulesModel extends BaseIssuanceModel {
     this.clientRevocationDisabled = input.clientRevocationDisabled ?? false;
 
     if (input.decryptionKeys) {
-      const arr = Array.from(input.decryptionKeys);
-      this.decryptionKeys = arr.map(RulesModel.createRemoteKey);
+      this.decryptionKeys = Array.from(input.decryptionKeys, RulesModel.createRemoteKey);
     }
 
     if (input.signingKeys) {
-      const arr = Array.from(input.signingKeys);
-      this.signingKeys = arr.map(RulesModel.createRemoteKey);
+      this.signingKeys = Array.from(input.signingKeys, RulesModel.createRemoteKey);
     }
 
     if (input.refresh) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.10.1-preview.10",
+  "version": "0.10.1-preview.13",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
@@ -47,7 +47,7 @@
     "jsonpath": "1.0.2",
     "multihashes": "0.4.14",
     "uuid": "7.0.1",
-    "verifiablecredentials-crypto-sdk-typescript": "1.1.11-preview.7"
+    "verifiablecredentials-crypto-sdk-typescript": "1.1.11-preview.8"
   },
   "nyc": {
     "extension": [

--- a/tests/InputModel.spec.ts
+++ b/tests/InputModel.spec.ts
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+  BaseAttestationModel,
+  IdTokenAttestationModel,
+  InputClaimModel,
+  InputModel,
+  IssuanceAttestationsModel,
+  RefreshConfigurationModel,
+  RemoteKeyAuthorizationModel,
+  RemoteKeyModel,
+  RulesModel,
+  SelfIssuedAttestationModel,
+  TransformModel,
+  TrustedIssuerModel,
+  VerifiableCredentialModel,
+  VerifiablePresentationAttestationModel,
+} from '../lib';
+
+describe('InputModel', () => {
+  let rulesModel: RulesModel;
+
+  beforeAll(() => {
+    rulesModel = new RulesModel(
+      'issuer uri',
+      'issuer',
+      new IssuanceAttestationsModel(
+        new SelfIssuedAttestationModel(
+          {
+            alias: new InputClaimModel('name', 'string', false, true, new TransformModel('name', 'remote'))
+          },
+          false,
+          undefined,
+          true
+        ),
+        [
+          new VerifiablePresentationAttestationModel(
+            'CredentialType',
+            5 * 60,
+            [
+              new TrustedIssuerModel('trusted issuer 1'),
+              new TrustedIssuerModel('trusted issuer 2')
+            ],
+            [
+              new TrustedIssuerModel('endorser')
+            ],
+            [
+              'contract'
+            ],
+            {
+              givenName: new InputClaimModel('vc.credentialSubject.givenName'),
+              familyName: new InputClaimModel('vc.credentialSubject.familyName', 'string', true)
+            })
+        ],
+        [
+          new IdTokenAttestationModel(
+            'oidc config endpoint',
+            'clientId',
+            'redirect',
+            'scope',
+            {
+              email: new InputClaimModel('upn', 'string', false, true),
+              name: new InputClaimModel('name')
+            }
+          ),
+        ]),
+      86400,
+      [
+        new RemoteKeyModel(undefined, undefined, 'x5t', 'pfx', true, new RemoteKeyAuthorizationModel('msi')),
+        new RemoteKeyModel('kid', 'key', undefined, undefined, true, new RemoteKeyAuthorizationModel('msi')),
+      ],
+      [
+        new RemoteKeyModel('kid', 'key', undefined, undefined, false, new RemoteKeyAuthorizationModel('msi')),
+      ],
+      new RefreshConfigurationModel(604800),
+      true,
+      true,
+      new VerifiableCredentialModel(
+        ['urn:test:context'],
+        ['EmployeeCredential'],
+        {
+          put: {
+            an: 'object',
+            here: true
+          }
+        },
+      ),
+      true,
+      [
+        new TrustedIssuerModel('end1')
+      ],
+    );
+  });
+
+  it('should perserve all attributes of parsed rules input claims', () => {
+    const inputModel = new InputModel(rulesModel);
+    const attestations = rulesModel.attestations!;
+    const outputAttestations = inputModel.attestations!;
+    const selfIssued = outputAttestations.selfIssued!;
+    const presentations = outputAttestations.presentations!;
+    const idTokens = outputAttestations.idTokens!;
+
+    Object.values(attestations.selfIssued!.mapping!).forEach(({ claim, type, required, indexed }) => {
+      const outputClaim = selfIssued.claims!.find(({ claim: claimName }) => claimName === claim);
+      expect(outputClaim instanceof InputClaimModel).toEqual(true);
+
+      expect(outputClaim!.claim).toEqual(claim);
+      expect(outputClaim!.type).toEqual(type);
+      expect(outputClaim!.required).toEqual(required);
+      expect(outputClaim!.indexed).toEqual(indexed);
+    });
+
+    attestations.presentations!.forEach(({ mapping }) => {
+      Object.values(mapping!).forEach(({ claim, type, required, indexed }) => {
+        const outputPresentation = presentations.find(({ claims }) => claims!.find(({ claim: claimName }) => claimName === claim));
+        expect(outputPresentation instanceof BaseAttestationModel).toEqual(true);
+        
+        const outputClaim = outputPresentation!.claims!.find(({ claim: claimName }) => claimName === claim);
+        expect(outputClaim instanceof InputClaimModel).toEqual(true);
+  
+        expect(outputClaim!.claim).toEqual(claim);
+        expect(outputClaim!.type).toEqual(type);
+        expect(outputClaim!.required).toEqual(required);
+        expect(outputClaim!.indexed).toEqual(indexed);
+      });
+    });
+
+    attestations.idTokens!.forEach(({ mapping }) => {
+      Object.values(mapping!).forEach(({ claim, type, required, indexed }) => {
+        const outputIdToken = idTokens.find(({ claims }) => claims!.find(({ claim: claimName }) => claimName === claim));
+        expect(outputIdToken instanceof BaseAttestationModel).toEqual(true);
+        const outputClaim = outputIdToken!.claims!.find(({ claim: claimName }) => claimName === claim);
+        expect(outputClaim instanceof InputClaimModel).toEqual(true);
+  
+        expect(outputClaim!.claim).toEqual(claim);
+        expect(outputClaim!.type).toEqual(type);
+        expect(outputClaim!.required).toEqual(required);
+        expect(outputClaim!.indexed).toEqual(indexed);
+      });
+    });
+  });
+});

--- a/tests/RulesModel.spec.ts
+++ b/tests/RulesModel.spec.ts
@@ -6,75 +6,79 @@
 import { IdTokenAttestationModel, InputClaimModel, InputModel, IssuanceAttestationsModel, RefreshConfigurationModel, RemoteKeyAuthorizationModel, RemoteKeyModel, RulesModel, SelfIssuedAttestationModel, TransformModel, TrustedIssuerModel, VerifiableCredentialModel, VerifiablePresentationAttestationModel } from '../lib';
 
 describe('RulesModel', () => {
-  const RULES = new RulesModel(
-    'issuer uri',
-    'issuer',
-    new IssuanceAttestationsModel(
-      new SelfIssuedAttestationModel(
-        {
-          alias: new InputClaimModel('name', 'string', false, true, new TransformModel('name', 'remote'))
-        },
-        false,
-        undefined,
-        true
-      ),
-      [
-        new VerifiablePresentationAttestationModel(
-          'CredentialType',
-          5 * 60,
-          [
-            new TrustedIssuerModel('trusted issuer 1'),
-            new TrustedIssuerModel('trusted issuer 2')
-          ],
-          [
-            new TrustedIssuerModel('endorser')
-          ],
-          [
-            'contract'
-          ],
+  let RULES: RulesModel;
+
+  beforeAll(() => {
+    RULES = new RulesModel(
+      'issuer uri',
+      'issuer',
+      new IssuanceAttestationsModel(
+        new SelfIssuedAttestationModel(
           {
-            givenName: new InputClaimModel('vc.credentialSubject.givenName'),
-            familyName: new InputClaimModel('vc.credentialSubject.familyName', 'string', true)
-          })
+            alias: new InputClaimModel('name', 'string', false, true, new TransformModel('name', 'remote'))
+          },
+          false,
+          undefined,
+          true
+        ),
+        [
+          new VerifiablePresentationAttestationModel(
+            'CredentialType',
+            5 * 60,
+            [
+              new TrustedIssuerModel('trusted issuer 1'),
+              new TrustedIssuerModel('trusted issuer 2')
+            ],
+            [
+              new TrustedIssuerModel('endorser')
+            ],
+            [
+              'contract'
+            ],
+            {
+              givenName: new InputClaimModel('vc.credentialSubject.givenName'),
+              familyName: new InputClaimModel('vc.credentialSubject.familyName', 'string', true)
+            })
+        ],
+        [
+          new IdTokenAttestationModel(
+            'oidc config endpoint',
+            'clientId',
+            'redirect',
+            'scope',
+            {
+              email: new InputClaimModel('upn', 'string', false, true),
+              name: new InputClaimModel('name')
+            }
+          ),
+        ]),
+      86400,
+      [
+        new RemoteKeyModel(undefined, undefined, 'x5t', 'pfx', true, new RemoteKeyAuthorizationModel('msi')),
+        new RemoteKeyModel('kid', 'key', undefined, undefined, true, new RemoteKeyAuthorizationModel('msi')),
       ],
       [
-        new IdTokenAttestationModel(
-          'oidc config endpoint',
-          'clientId',
-          'redirect',
-          'scope',
-          {
-            email: new InputClaimModel('upn', 'string', false, true),
-            name: new InputClaimModel('name')
+        new RemoteKeyModel('kid', 'key', undefined, undefined, false, new RemoteKeyAuthorizationModel('msi')),
+      ],
+      new RefreshConfigurationModel(604800),
+      true,
+      true,
+      new VerifiableCredentialModel(
+        ['urn:test:context'],
+        ['EmployeeCredential'],
+        {
+          put: {
+            an: 'object',
+            here: true
           }
-        ),
-      ]),
-    86400,
-    [
-      new RemoteKeyModel(undefined, undefined, 'x5t', 'pfx', true, new RemoteKeyAuthorizationModel('msi')),
-      new RemoteKeyModel('kid', 'key', undefined, undefined, true, new RemoteKeyAuthorizationModel('msi')),
-    ],
-    [
-      new RemoteKeyModel('kid', 'key', undefined, undefined, false, new RemoteKeyAuthorizationModel('msi')),
-    ],
-    new RefreshConfigurationModel(604800),
-    true,
-    true,
-    new VerifiableCredentialModel(
-      ['urn:test:context'],
-      ['EmployeeCredential'],
-      {
-        put: {
-          an: 'object',
-          here: true
-        }
-      },
-    ),
-    true,
-    [
-      new TrustedIssuerModel('end1')
-    ],
-  );
+        },
+      ),
+      true,
+      [
+        new TrustedIssuerModel('end1')
+      ],
+    );
+  });
 
   // tslint:disable-next-line:max-func-body-length
   describe('RulesModel class serialization', () => {
@@ -279,6 +283,18 @@ describe('RulesModel', () => {
       const roundtrip = new RulesModel();
       roundtrip.populateFrom({ ...JSON.parse(json), attestations: undefined });
       expect(roundtrip.attestations).toBeUndefined();
+    });
+
+    it('should trigger error if mapping names are not unique', () => {
+      // Make self-issued attestation duplicate.
+      RULES.attestations!.selfIssued!.mapping!.name = new InputClaimModel('dulpicateName', 'String');
+
+      const json = JSON.stringify(RULES);
+      const roundtrip = new RulesModel();
+      expect(() => roundtrip.populateFrom(JSON.parse(json))).toThrowError();
+
+      // Reset self-issued attestations.
+      delete RULES.attestations!.selfIssued!.mapping!.name;
     });
   });
 

--- a/tests/RulesModel.spec.ts
+++ b/tests/RulesModel.spec.ts
@@ -273,6 +273,13 @@ describe('RulesModel', () => {
       vpModel.populateFrom({});
       expect(vpModel).toBeDefined();
     });
+
+    it('should accept models with no attestations', () => {
+      const json = JSON.stringify(RULES);
+      const roundtrip = new RulesModel();
+      roundtrip.populateFrom({ ...JSON.parse(json), attestations: undefined });
+      expect(roundtrip.attestations).toBeUndefined();
+    });
   });
 
   describe('attestations.indexClaims', () => {

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -24,7 +24,7 @@ describe('VerifiableCredentialValidation', () => {
     let validator = new VerifiableCredentialValidation(options, expected);
     let response = await validator.validate(siop.vc.rawToken, setup.defaultUserDid);
     expect(response.result).toBeTruthy();
-    expect(response.subject).toEqual(setup.defaultUserDid);
+    expect(response.payloadObject.credentialSubject.id).toEqual(setup.defaultUserDid);
 
     // Negative cases
 

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -7,7 +7,7 @@ import { IssuanceHelpers } from './IssuanceHelpers';
 import { VerifiableCredentialValidation } from '../lib/input_validation/VerifiableCredentialValidation';
 import { TokenType, IExpectedVerifiableCredential, Validator } from '../lib';
 
- describe('VerifiableCredentialValidation', () => {
+describe('VerifiableCredentialValidation', () => {
   let setup: TestSetup;
   beforeEach(async () => {
     setup = new TestSetup();
@@ -18,12 +18,13 @@ import { TokenType, IExpectedVerifiableCredential, Validator } from '../lib';
   });
 
   it('should test validate', async () => {
-    const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.verifiableCredential, true);   
+    const [_, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.verifiableCredential, true);   
     const expected = siop.expected.filter((token: IExpectedVerifiableCredential) => token.type === TokenType.verifiableCredential)[0];
 
     let validator = new VerifiableCredentialValidation(options, expected);
     let response = await validator.validate(siop.vc.rawToken, setup.defaultUserDid);
     expect(response.result).toBeTruthy();
+    expect(response.subject).toEqual(setup.defaultUserDid);
 
     // Negative cases
 


### PR DESCRIPTION
**Problem:**
- BaseIssuanceModel enforces the existence of attestations. Some valid scenarios (e.g. ClaimProviders) do not include attestations.
- InputModel claims populated from RulesModel instances do not preserve indexed claims set to true.
- IssuanceAttestationsModel can be populated with duplicate attestation mapping names, leading to potential data loss.
- In order to support JSON-LD, VerifiableCredentialValidation no longer includes the outer Verifiable Credential payload.


**Solution:**
Updated BaseIssuanceModel, InputModel, IssuanceAttestationsModel, and VerifiableCredentialValidation.


**Validation:**
New unit tests added.


**Type of change:**
- [x] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1059795


**Documentation Links**:
https://microsoft.sharepoint.com/:w:/t/ProjectAspen/EZrgaKQGz1hAsEHIvbi_gkkBQAooRqiZIZMezd8D-QT3tQ?e=O1LrmZ
