### PR TITLE
VC Subject in Validation Object

### DIFF
--- a/lib/input_validation/VerifiableCredentialValidation.ts
+++ b/lib/input_validation/VerifiableCredentialValidation.ts
@@ -41,9 +41,8 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
     }
 
     const isJwt = typeof verifiableCredential === 'string';
-    let sub: string | undefined;
     if (isJwt) {
-      sub = validationResponse.payloadObject.sub;
+      validationResponse.subject = validationResponse.payloadObject.sub;
       if (!validationResponse.payloadObject.vc) {
         return {
           result: false,
@@ -95,7 +94,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
 
     if (isJwt) {
       // Check token sub
-      if (!sub) {
+      if (!validationResponse.subject) {
         return {
           result: false,
           detailedError: `Missing sub property in verifiableCredential. Expected '${siopDid}'`,
@@ -104,17 +103,12 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       }
 
       // check sub value
-      if (siopDid && sub !== siopDid) {
+      if (siopDid && validationResponse.subject !== siopDid) {
         return {
           result: false,
           detailedError: `Wrong sub property in verifiableCredential. Expected '${siopDid}'`,
           status: 403
         };
-      }
-
-      // make sure the sub claim is the id in the credentialSubject
-      if (!validationResponse.payloadObject.credentialSubject.id) {
-        validationResponse.payloadObject.credentialSubject.id = sub;
       }
     } else {
       let subjects = [];

--- a/lib/input_validation/VerifiableCredentialValidationResponse.ts
+++ b/lib/input_validation/VerifiableCredentialValidationResponse.ts
@@ -6,6 +6,10 @@
 import { IValidationResponse } from './IValidationResponse';
 
 export interface VerifiableCredentialValidationResponse extends IValidationResponse {
+  /**
+   * Verifiable Credential subject did.
+   */
+  subject?: string;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.10.1-preview.13",
+  "version": "0.10.1-preview.15",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -24,7 +24,7 @@ describe('VerifiableCredentialValidation', () => {
     let validator = new VerifiableCredentialValidation(options, expected);
     let response = await validator.validate(siop.vc.rawToken, setup.defaultUserDid);
     expect(response.result).toBeTruthy();
-    expect(response.payloadObject.credentialSubject.id).toEqual(setup.defaultUserDid);
+    expect(response.subject).toEqual(setup.defaultUserDid);
 
     // Negative cases
 


### PR DESCRIPTION
**Problem:**
Mutating credentialSubject.id to include the subject DID is a breaking change for exchange.


**Solution:**
Move the subject DID out of the payload object and into the validation response object.


**Validation:**
Updated unit test. 


**Type of change:**
- [x] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1059795


**Documentation Links**:
https://microsoft.sharepoint.com/:w:/t/ProjectAspen/EZrgaKQGz1hAsEHIvbi_gkkBQAooRqiZIZMezd8D-QT3tQ?e=O1LrmZ
