### PR TITLE
Create a delegate for fetching Open id Token Public Keys 

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -37,6 +37,10 @@ The client_id property of the OIDC request will always be equal to redirect_uri.
 **Type of change:** engineering    
 **Customer impact:** low
 
+## Refactored OpenId public key fetching to allow for caching
+**Type of change:** engineering    
+**Customer impact:** low
+
 See change log here: https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript/blob/master/CHANGE_LOG.md
 
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,13 @@
+# version 0.11.1-preview.1
+## Refactored OpenId public key fetching to allow for caching
+**Type of change:** engineering    
+**Customer impact:** low
+
+# version 0.11.1-preview.0
+## Rules Model updates to support extensiblity features
+**Type of change:** new feature    
+**Customer impact:** low
+
 # version 0.10.1
 ## Support for json-ld proofs
 **Type of change:** new feature    
@@ -34,10 +44,6 @@ The client_id property of the OIDC request will always be equal to redirect_uri.
 
 
 ## Updated to verifiablecredentials-crypto-sdk-typescript v1.1.11
-**Type of change:** engineering    
-**Customer impact:** low
-
-## Refactored OpenId public key fetching to allow for caching
 **Type of change:** engineering    
 **Customer impact:** low
 

--- a/lib/options/IValidationOptions.ts
+++ b/lib/options/IValidationOptions.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import ClaimToken, { TokenType } from '../verifiable_credential/ClaimToken';
+import ClaimToken from '../verifiable_credential/ClaimToken';
 import { IValidationResponse } from '../input_validation/IValidationResponse';
 import { IPayloadProtectionSigning } from 'verifiablecredentials-crypto-sdk-typescript';
 import { ValidationHelpers } from '../input_validation/ValidationHelpers';
@@ -21,6 +21,7 @@ import { IExpectedBase, IExpectedVerifiablePresentation, IExpectedVerifiableCred
  export type FetchKeyAndValidateSignatureOnIdToken = (validationResponse: IValidationResponse, token: ClaimToken) => Promise<IValidationResponse>;
  export type ValidateSignatureOnToken = (validationResponse: IValidationResponse, token: ClaimToken, key: any) => Promise<IValidationResponse>;
  export type GetTokensFromSiop = (validationResponse: IValidationResponse) => IValidationResponse;
+ export type FetchOpenIdTokenPublicKeys = (validationResponse: IValidationResponse, token: ClaimToken) => Promise<IValidationResponse | any>;
 
  /**
  *Interface to model validation options
@@ -85,4 +86,9 @@ getTokenObjectDelegate: GetTokenObject;
    * Signature validation
    */
   validateSignatureOnTokenDelegate: ValidateSignatureOnToken,
+
+  /**
+   * fetch the public keys of an OpenId Provider
+   */
+  fetchOpenIdTokenPublicKeysDelegate: FetchOpenIdTokenPublicKeys,
 }

--- a/lib/options/ValidationOptions.ts
+++ b/lib/options/ValidationOptions.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { FetchKeyAndValidateSignatureOnIdToken, IValidationOptions, CheckTimeValidityOnToken, ResolveDidAndGetKeys, GetTokenObject, ValidateDidSignature, CheckScopeValidityOnToken, ValidateSignatureOnToken, GetTokensFromSiop, CheckScopeValidityOnVcToken, CheckScopeValidityOnIdToken, CheckScopeValidityOnVpToken } from './IValidationOptions';
+import { FetchKeyAndValidateSignatureOnIdToken, IValidationOptions, CheckTimeValidityOnToken, ResolveDidAndGetKeys, GetTokenObject, ValidateDidSignature, CheckScopeValidityOnToken, ValidateSignatureOnToken, CheckScopeValidityOnVcToken, CheckScopeValidityOnIdToken, CheckScopeValidityOnVpToken, FetchOpenIdTokenPublicKeys } from './IValidationOptions';
 import { ValidationHelpers } from '../input_validation/ValidationHelpers';
 import IValidatorOptions from './IValidatorOptions';
 import { TokenType } from '../index';
@@ -30,6 +30,7 @@ constructor (public validatorOptions: IValidatorOptions, public tokenType: Token
   this.checkScopeValidityOnVcTokenDelegate = this.validationHelpers.checkScopeValidityOnVcToken;
   this.fetchKeyAndValidateSignatureOnIdTokenDelegate = this.validationHelpers.fetchKeyAndValidateSignatureOnIdToken;
   this.validateSignatureOnTokenDelegate = this.validationHelpers.validateSignatureOnToken;
+  this.fetchOpenIdTokenPublicKeysDelegate = this.validationHelpers.fetchOpenIdTokenPublicKeys;
 }
 
 /**
@@ -86,4 +87,9 @@ public getTokenObjectDelegate: GetTokenObject;
    * Signature validation
    */
   public validateSignatureOnTokenDelegate: ValidateSignatureOnToken;
+
+    /**
+   * fetch the public keys of an OpenId Provider
+   */
+  public fetchOpenIdTokenPublicKeysDelegate: FetchOpenIdTokenPublicKeys;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.11.1-preview.0",
+  "version": "0.11.1-preview.1",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/ValidationHelpers.spec.ts
+++ b/tests/ValidationHelpers.spec.ts
@@ -238,8 +238,8 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
     expect(response.detailedError).toEqual(`The issuer in configuration 'iss' does not correspond with the issuer in the payload xxx`);
     validationResponse.issuer = issuer;
     });
-    
-  it('should test fetchKeyAndValidateSignatureOnIdTokenDelegate', async () => {
+
+    it('should test fetchKeyAndValidateSignatureOnIdTokenDelegate', async () => {
       const options = new ValidationOptions(setup.validatorOptions, TokenType.idToken);
       const validationResponse: IValidationResponse = {
         status: 200,
@@ -343,5 +343,26 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
       expect(response.result).toBeFalsy();
       expect(response.status).toEqual(403);
       expect(response.detailedError).toEqual(`Could not validate signature on id token`);
+  });
+
+  it('should test fetchOpenIdTokenPublicKeysDelegate', async () => {
+      const options = new ValidationOptions(setup.validatorOptions, TokenType.idToken);
+      const validationResponse: IValidationResponse = {
+        status: 200,
+        result: true
+      };
+  
+      let [tokenJwkPrivate, tokenJwkPublic, tokenConfiguration] = await IssuanceHelpers.generateSigningKeyAndSetConfigurationMock(setup, setup.defaulIssuerDidKid); 
+      const payload = {
+        jti: 'jti'
+      };
+
+      const idToken = await IssuanceHelpers.signAToken(setup, payload, tokenConfiguration, tokenJwkPrivate);
+
+      let response = await options.fetchOpenIdTokenPublicKeysDelegate(validationResponse, idToken);
+      expect(response).toBeDefined();
+      expect(response.keys).toBeDefined();
+      expect(Array.isArray(response.keys)).toBeTruthy();
+      expect((<Array<any>>response.keys).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Create a delegate for fetching Open id Token Public Keys to allow caching of known public keys

**Problem:**
Each validation of an Id Token has a 1:1 fetch of Open Id Configuration and then the jwks_uri in the configuration.  Under minor load, this becomes a latency issue.  Furthermore, there's a need to have telemetry in services to measure this latency


**Solution:**
Split public key fetching from fetchKeyAndValidateSignatureOnIdToken into its own delegate


**Validation:**
Existing tests continue to work


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1215158