### PR TITLE
Fix bug where an expiration of zero was treated the same as no expiration

### DIFF
--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -236,7 +236,8 @@ export class ValidationHelpers {
     const self: any = this;
     const current = Math.trunc(Date.now() / 1000);
 
-    if (validationResponse.expiration) {
+    // a falsy check is insufficient, zero is a valid epoch time
+    if (validationResponse.expiration !== undefined) {
       // initialize in utc time
       const exp = (validationResponse.expiration + clockSkewToleranceSeconds);
 

--- a/tests/ValidationHelpers.spec.ts
+++ b/tests/ValidationHelpers.spec.ts
@@ -168,6 +168,12 @@ import { IExpectedSiop, IExpectedIdToken, IExpectedAudience, IdTokenValidationRe
     expect(response.status).toEqual(403);
     expect(response.detailedError?.startsWith('The presented verifiableCredential is expired')).toBeTruthy();
     
+    validationResponse.expiration = 0;
+    response = options.checkTimeValidityOnTokenDelegate(validationResponse, 5);
+    expect(response.result).toBeFalsy('expired');
+    expect(response.status).toEqual(403);
+    expect(response.detailedError?.startsWith('The presented verifiableCredential is expired')).toBeTruthy();
+    
     // Add nbf
     validationResponse.expiration = undefined;
     let nbf = new Date().getTime() / 1000;


### PR DESCRIPTION
**Problem:**
An expiration of 0 which is a valid epoch time, is treated the same as no expiration.  In the case of a expiration = 0, a token is validated when in fact it should be rejected as expired


**Solution:**
Check for undefined instead of truthy


**Validation:**
Added a new test case


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

