### PR TITLE
Add errorcode to ClaimToken

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,13 +5,24 @@
 The validation response return code, a string which contains a unique value for the error.
 The error code is fixed in unit tests
 
+    console.log(validationResponse.code); // for seeing the code
+    console.log(validationResponse.status); // for seeing the suggested status to return to client
+    console.log(validationResponse.detailedError); // for seeing the detailed error message
+
 
 ## Allow IValidationOptions to be specified via ValidatorBuilder
 **Type of change:** feature    
 **Customer impact:** low
 
-Removed IHttpClientOptions because not used anymore.
+Removed IHttpClientOptions because it is not used anymore.
+
 VerifiablePresentationTokenValidator ctor no longer uses the crypto argument.
+
+Add validationOptions property to ValidatorBuilder
+
+    // Retrieve the validator options from the builder state
+    const options = validationBuilder.validationOptions;  
+
 
 # version 0.11.1
 ## Turn 0.11.1-preview.5 into the released package

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,10 @@
+# version 0.12.1-preview.0
+## Add error codes to the validation response
+**Type of change:** engineering    
+**Customer impact:** low
+The validation response return code, a string which contains a unique value for the error.
+The error code is fixed in unit tests
+
 # version 0.11.1
 ## Turn 0.11.1-preview.5 into the released package
 

--- a/lib/api_oidc_request/Requestor.ts
+++ b/lib/api_oidc_request/Requestor.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestorBuilder, IRequestorAttestation, IRequestorPresentationExchange, IssuerMap, IssuanceAttestationsModel, IdTokenAttestationModel, VerifiablePresentationAttestationModel } from '../index';
+import { RequestorBuilder, IRequestorAttestation, IRequestorPresentationExchange, IssuerMap, IssuanceAttestationsModel, IdTokenAttestationModel, VerifiablePresentationAttestationModel, ValidationError } from '../index';
 import { PresentationProtocol } from './RequestorBuilder';
 import { IRequestorResult } from './IRequestorResult';
 import { JoseBuilder } from 'verifiablecredentials-crypto-sdk-typescript';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKREQU', error);
 
 /**
  * Class to model the OIDC requestor
@@ -137,7 +139,7 @@ export default class Requestor {
         return <string[]>configurations.filter((config: string | undefined) => config);
       }
     } else {
-      throw new Error('Id Tokens only supported in Attestation Requestor model.');
+      throw new ValidationError(`Id Tokens only supported in Attestation Requestor model.`, errorCode(1));
     }
   }
 
@@ -156,12 +158,12 @@ export default class Requestor {
       const issuers: { [credentialType: string]: string[] } = {};
       for (let definition in presentationDefinition.input_descriptors) {
         if (!presentationDefinition.input_descriptors[definition]) {
-          throw new Error('Missing id in input_descriptor');
+          throw new ValidationError('Missing id in input_descriptor');
         }
       }
       return issuers;
       */
-     throw new Error('trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.')
+     throw new ValidationError('trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.', errorCode(2));
     } else {
       const attestations = (<IRequestorAttestation>this.builder.requestor).attestations;
       if (!attestations.presentations) {
@@ -170,7 +172,7 @@ export default class Requestor {
         attestations.presentations.forEach((presentation) => {
 
           if (!presentation.credentialType) {
-            throw new Error('Missing credentialType for presentation.');
+            throw new ValidationError('Missing credentialType for presentation.', errorCode(3));
           }
           if (!issuers[presentation.credentialType]) {
             issuers[presentation.credentialType] = [];

--- a/lib/api_oidc_request/Requestor.ts
+++ b/lib/api_oidc_request/Requestor.ts
@@ -8,7 +8,7 @@ import { PresentationProtocol } from './RequestorBuilder';
 import { IRequestorResult } from './IRequestorResult';
 import { JoseBuilder } from 'verifiablecredentials-crypto-sdk-typescript';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
-const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKREQU', error);
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKRequ', error);
 
 /**
  * Class to model the OIDC requestor

--- a/lib/api_validation/IdTokenTokenValidator.ts
+++ b/lib/api_validation/IdTokenTokenValidator.ts
@@ -3,13 +3,15 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TokenType, IExpectedIdToken, ITokenValidator, ClaimToken } from '../index';
+import { TokenType, IExpectedIdToken, ITokenValidator, ClaimToken, ValidationError } from '../index';
 import { IValidationResponse } from '../input_validation/IValidationResponse';
 import ValidationOptions from '../options/ValidationOptions';
 import IValidatorOptions from '../options/IValidatorOptions';
 import { IdTokenValidation } from '../input_validation/IdTokenValidation';
 import ValidationQueue from '../input_validation/ValidationQueue';
 import ValidationQueueItem from '../input_validation/ValidationQueueItem';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKIDTV', error);
 
 /**
  * Class to validate a token
@@ -45,7 +47,7 @@ export default class IdTokenTokenValidator implements ITokenValidator {
    * @param queue with tokens to validate
    */
   public getTokens(_validationResponse: IValidationResponse, _queue: ValidationQueue ): IValidationResponse {
-    throw new Error('Not implemented');
+    throw new ValidationError(`Not implemented`, errorCode(1));
   }
 
   /**

--- a/lib/api_validation/SelfIssuedTokenValidator.ts
+++ b/lib/api_validation/SelfIssuedTokenValidator.ts
@@ -3,12 +3,14 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IExpectedSelfIssued, ITokenValidator, TokenType } from '../index';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+import { IExpectedSelfIssued, ITokenValidator, TokenType, ValidationError } from '../index';
 import { IValidationResponse } from '../input_validation/IValidationResponse';
 import ValidationQueue from '../input_validation/ValidationQueue';
 import ValidationQueueItem from '../input_validation/ValidationQueueItem';
 import IValidatorOptions from '../options/IValidatorOptions';
 import ValidationOptions from '../options/ValidationOptions';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKSITV', error);
 
 /**
  * Class to validate a token
@@ -46,7 +48,7 @@ export default class SelfIssuedTokenValidator implements ITokenValidator {
    * @param queue with tokens to validate
    */
   public getTokens(_validationResponse: IValidationResponse, _queue: ValidationQueue ): IValidationResponse {
-    throw new Error('Not implemented');
+    throw new ValidationError(`Not implemented`, errorCode(1));
   }
 
   /**

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -11,6 +11,8 @@ import ValidationQueue from '../input_validation/ValidationQueue';
 import ValidationQueueItem from '../input_validation/ValidationQueueItem';
 import { SiopValidation } from '../input_validation/SiopValidation';
 import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKSTVA', error);
 
 /**
  * Class to validate a token
@@ -52,7 +54,8 @@ export default class SiopTokenValidator implements ITokenValidator {
         return {
           result: false,
           status: 403,
-          detailedError: `Expect nonce '${this.expected.nonce}' does not match '${validationResponse.payloadObject.nonce}'.`
+          code: errorCode(1),
+          detailedError: `Expected nonce '${this.expected.nonce}' does not match '${validationResponse.payloadObject.nonce}'.`
         }
       }
     }
@@ -61,7 +64,8 @@ export default class SiopTokenValidator implements ITokenValidator {
         return {
           result: false,
           status: 403,
-          detailedError: `Expect state '${this.expected.state}' does not match '${validationResponse.payloadObject.state}'.`
+          code: errorCode(2),
+          detailedError: `Expected state '${this.expected.state}' does not match '${validationResponse.payloadObject.state}'.`
         }
       }
     }

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -12,7 +12,7 @@ import ValidationQueueItem from '../input_validation/ValidationQueueItem';
 import { SiopValidation } from '../input_validation/SiopValidation';
 import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
-const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKSTVA', error);
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKSTVa', error);
 
 /**
  * Class to validate a token

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -100,9 +100,10 @@ export default class SiopTokenValidator implements ITokenValidator {
             console.error(err);
             return {
               result: false,
-              status: 403,
+              status: 400,
               detailedError: err.message,
-              code: err.code
+              code: errorCode(3),
+              innerError: err
             };
           }
         }
@@ -120,10 +121,19 @@ export default class SiopTokenValidator implements ITokenValidator {
             result: false,
             status: 403,
             detailedError: err.message,
-            code: err.code
-          };
+            code: errorCode(4),
+            innerError: err
+        };
         }
         break;
+
+      default:
+          return {
+            result: false,
+            status: 400,
+            detailedError: 'Not a valid SIOP',
+            code: errorCode(5)
+        };
     }
     if (validationResponse.tokensToValidate) {
       for (let key in validationResponse.tokensToValidate) {

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -97,7 +97,8 @@ export default class SiopTokenValidator implements ITokenValidator {
             return {
               result: false,
               status: 403,
-              detailedError: err.message
+              detailedError: err.message,
+              code: err.code
             };
           }
         }

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -114,7 +114,8 @@ export default class SiopTokenValidator implements ITokenValidator {
           return {
             result: false,
             status: 403,
-            detailedError: err.message
+            detailedError: err.message,
+            code: err.code
           };
         }
         break;

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -62,6 +62,7 @@ export default class Validator {
         return {
           status: 400,
           detailedError: exception.message,
+          code: exception.code,
           result: false
         }
       }
@@ -83,6 +84,7 @@ export default class Validator {
       } catch (error) {
         return {
           detailedError: error.message,
+          code: error.code,
           status: 400,
           result: false
         };

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -64,7 +64,8 @@ export default class Validator {
         return {
           status: 400,
           detailedError: exception.message,
-          code: exception.code,
+          code: errorCode(8),
+          innerError: exception,
           result: false
         }
       }
@@ -84,10 +85,11 @@ export default class Validator {
     do {
       try {
         claimToken = Validator.getClaimToken(queueItem!);
-      } catch (error) {
+      } catch (exception) {
         return {
-          detailedError: error.message,
-          code: error.code,
+          detailedError: exception.message,
+          code: errorCode(9),
+          innerError: exception,
           status: 400,
           result: false
         };
@@ -191,7 +193,7 @@ export default class Validator {
           return {
             detailedError: `Verifiable credential '${vc}' is missing from the input request`,
             code: errorCode(4),
-            status: 403,
+            status: 401,
             result: false
           };
         }
@@ -205,7 +207,7 @@ export default class Validator {
         return {
           code: errorCode(5),
           detailedError: `The id token is missing from the input request`,
-          status: 403,
+          status: 401,
           result: false
         };
       }

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -13,7 +13,7 @@ import { KeyStoreOptions } from 'verifiablecredentials-crypto-sdk-typescript';
 import { VerifiablePresentationValidationResponse } from '../input_validation/VerifiablePresentationValidationResponse';
 import { v4 as uuid } from 'uuid';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
-const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVTOR', error);
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVtor', error);
 
 /**
  * Class model the token validator

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -12,6 +12,8 @@ import IValidationResult from './IValidationResult';
 import { KeyStoreOptions } from 'verifiablecredentials-crypto-sdk-typescript';
 import { VerifiablePresentationValidationResponse } from '../input_validation/VerifiablePresentationValidationResponse';
 import { v4 as uuid } from 'uuid';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVTOR', error);
 
 /**
  * Class model the token validator
@@ -72,6 +74,7 @@ export default class Validator {
       return {
         result: false,
         status: 400,
+        code: errorCode(1),
         detailedError: 'Wrong token type. Expected string or ClaimToken'
       }
     }
@@ -94,6 +97,7 @@ export default class Validator {
       if (!validator) {
         return {
           detailedError: `${claimToken.type} does not has a TokenValidator`,
+          code: errorCode(2),
           status: 500,
           result: false
         };
@@ -136,6 +140,7 @@ export default class Validator {
         default:
           return {
             detailedError: `${claimToken.type} is not supported`,
+            code: errorCode(3),
             status: 400,
             result: false
           };
@@ -185,6 +190,7 @@ export default class Validator {
         if (!presentedVc) {
           return {
             detailedError: `Verifiable credential '${vc}' is missing from the input request`,
+            code: errorCode(4),
             status: 403,
             result: false
           };
@@ -197,6 +203,7 @@ export default class Validator {
     if (requiredidTokens && (Object.keys(requiredidTokens).length !== 0 || requiredidTokens.length > 0)) {
       if (!validationResult.idTokens) {
         return {
+          code: errorCode(5),
           detailedError: `The id token is missing from the input request`,
           status: 403,
           result: false
@@ -297,6 +304,7 @@ export default class Validator {
             return {
               result: false,
               status: 403,
+              code: errorCode(6),
               detailedError: `status check could not fetch response from ${statusUrl} with status ${response.status}. Message ${JSON.stringify(await response.json())}`
             };
           }
@@ -311,6 +319,7 @@ export default class Validator {
             validationResponse = {
               result: false,
               status: 403,
+              code: errorCode(7),
               detailedError: receipts.detailedError
             };
             break;

--- a/lib/api_validation/VerifiableCredentialTokenValidator.ts
+++ b/lib/api_validation/VerifiableCredentialTokenValidator.ts
@@ -3,13 +3,15 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IExpectedVerifiableCredential, ITokenValidator, TokenType } from '../index';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+import { IExpectedVerifiableCredential, ITokenValidator, TokenType, ValidationError } from '../index';
 import { IValidationResponse } from '../input_validation/IValidationResponse';
 import ValidationQueue from '../input_validation/ValidationQueue';
 import ValidationQueueItem from '../input_validation/ValidationQueueItem';
 import { VerifiableCredentialValidation } from '../input_validation/VerifiableCredentialValidation';
 import IValidatorOptions from '../options/IValidatorOptions';
 import ValidationOptions from '../options/ValidationOptions';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVCTV', error);
 
 /**
  * Class to validate a token
@@ -51,7 +53,7 @@ export default class VerifiableCredentialTokenValidator implements ITokenValidat
    * @param queue with tokens to validate
    */
   public getTokens(_validationResponse: IValidationResponse, _queue: ValidationQueue): IValidationResponse {
-    throw new Error('Not implemented');
+    throw new ValidationError(`Not implemented`, errorCode(1));
   }
 
   /**

--- a/lib/api_validation/VerifiablePresentationStatusReceipt.ts
+++ b/lib/api_validation/VerifiablePresentationStatusReceipt.ts
@@ -2,7 +2,9 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import ErrorHelpers from '../error_handling/ErrorHelpers';
 import { IValidationResponse, IValidationOptions, TokenType, ValidatorBuilder, DidValidation, IExpectedStatusReceipt, ClaimToken } from '../index';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVPSR', error);
 
 export interface IVerifiablePresentationStatus {
   id: string;
@@ -54,6 +56,7 @@ export default class VerifiablePresentationStatusReceipt {
       return {
         result: false,
         status: 403,
+        code: errorCode(1),
         detailedError: 'The status receipt is missing receipt'
       }
     }
@@ -81,6 +84,7 @@ export default class VerifiablePresentationStatusReceipt {
         return {
           result: false,
           status: 403,
+          code: errorCode(2),
           detailedError: `The status receipt iss '${receiptResponse.issuer}' is wrong. Expected '${this.expected.didIssuer}'`
         }
       }
@@ -97,6 +101,7 @@ export default class VerifiablePresentationStatusReceipt {
         return {
           result: false,
           status: 403,
+          code: errorCode(3),
           detailedError: `The status receipt for jti '${jti}' failed with status ${this.verifiablePresentationStatus![jti].status}.`
         }
       }

--- a/lib/api_validation/VerifiablePresentationTokenValidator.ts
+++ b/lib/api_validation/VerifiablePresentationTokenValidator.ts
@@ -11,6 +11,8 @@ import IValidatorOptions from '../options/IValidatorOptions';
 import ValidationQueue from '../input_validation/ValidationQueue';
 import ValidationQueueItem from '../input_validation/ValidationQueueItem';
 import { Crypto } from '../index';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVPTV', error);
 
 /**
  * Class to validate a token
@@ -53,6 +55,7 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
       return {
         result: false,
         status: 403,
+        code: errorCode(1),
         detailedError: 'No verifiable credential'
       };
     }

--- a/lib/error_handling/ErrorHelpers.ts
+++ b/lib/error_handling/ErrorHelpers.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+ export class ErrorHelpers {
+   /**
+    * 
+    * @param prefix for the error code
+    * @param errorNumber for the error code
+    * @param size of the errorNumber, defaults to two digits
+    */
+   public static errorCode(prefix: string, errorNumber: number, size: number = 2): string {
+    const paddedErrorNumber = (errorNumber + '').padStart(size, '0');
+    return prefix + paddedErrorNumber;
+   }
+ }

--- a/lib/error_handling/ErrorHelpers.ts
+++ b/lib/error_handling/ErrorHelpers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
- export class ErrorHelpers {
+ export default class ErrorHelpers {
    /**
     * 
     * @param prefix for the error code

--- a/lib/error_handling/ValidationError.ts
+++ b/lib/error_handling/ValidationError.ts
@@ -6,7 +6,7 @@
 /**
  * Typed error for validation failures.
  */
-export class ValidationError extends Error {
+export default class ValidationError extends Error {
   /**
    * Create a new instance of ValidationError
    * @param message describing the error message

--- a/lib/error_handling/ValidationError.ts
+++ b/lib/error_handling/ValidationError.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Typed error for validation failures.
+ */
+export class ValidationError extends Error {
+  /**
+   * Create a new instance of ValidationError
+   * @param message describing the error message
+   * @param code unique code the error
+   */
+  constructor(message: string, public code: string) {
+    super(message);
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,7 +13,8 @@ import {IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiabl
 export { IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSelfIssued, IExpectedIdToken, IExpectedOpenIdToken, IExpectedAudience, IssuerMap };
 
 import { RulesValidationError } from './error_handling/RulesValidationError';
-export { RulesValidationError };
+import { ValidationError } from './error_handling/ValidationError';
+export { RulesValidationError, ValidationError };
 
 import ManagedHttpResolver from './resolver/ManagedHttpResolver';
 export { ManagedHttpResolver };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,7 +13,7 @@ import {IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiabl
 export { IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSelfIssued, IExpectedIdToken, IExpectedOpenIdToken, IExpectedAudience, IssuerMap };
 
 import { RulesValidationError } from './error_handling/RulesValidationError';
-import { ValidationError } from './error_handling/ValidationError';
+import ValidationError from './error_handling/ValidationError';
 export { RulesValidationError, ValidationError };
 
 import ManagedHttpResolver from './resolver/ManagedHttpResolver';

--- a/lib/input_validation/DidValidation.ts
+++ b/lib/input_validation/DidValidation.ts
@@ -7,6 +7,8 @@ import { IPayloadProtectionSigning } from 'verifiablecredentials-crypto-sdk-type
 import { IDidValidation, IDidValidationResponse } from './DidValidationResponse';
 import { IValidationOptions } from '../options/IValidationOptions';
 import { IExpectedBase } from '../index';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKDIDV', error);
 
 /**
  * Class for input validation of a token signed with DID key
@@ -43,6 +45,7 @@ export class DidValidation implements IDidValidation {
      if (parts.length <= 1) {
        return {
          result: false,
+         code: errorCode(1),
          detailedError: `The kid in the protected header does not contain the DID. Required format for kid is <did>#kid`,
          status: 403
        };
@@ -52,6 +55,7 @@ export class DidValidation implements IDidValidation {
     if (!validationResponse.did) {
       return validationResponse = {
           result: false,
+          code: errorCode(2),
           detailedError: 'The kid does not contain the DID',
           status: 403
         };

--- a/lib/input_validation/IValidationResponse.ts
+++ b/lib/input_validation/IValidationResponse.ts
@@ -26,6 +26,11 @@ export interface IResponse {
   detailedError?: string;
 
   /**
+   * Output if false. Unique code for the response
+   */
+  code?: string;
+
+  /**
    * Additional error object
    */
   innerError?: any;

--- a/lib/input_validation/IdTokenValidation.ts
+++ b/lib/input_validation/IdTokenValidation.ts
@@ -8,7 +8,7 @@ import { IValidationOptions } from '../options/IValidationOptions';
 import ClaimToken, { TokenType } from '../verifiable_credential/ClaimToken';
 import { BaseIdTokenValidation } from './BaseIdTokenValidation';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
-const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKIDVA', error);
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKIDVa', error);
 
 /**
  * Class for id token validation for the Verifiable Credential attestation scenario

--- a/lib/input_validation/IdTokenValidation.ts
+++ b/lib/input_validation/IdTokenValidation.ts
@@ -7,6 +7,8 @@ import { IdTokenValidationResponse } from './IdTokenValidationResponse';
 import { IValidationOptions } from '../options/IValidationOptions';
 import ClaimToken, { TokenType } from '../verifiable_credential/ClaimToken';
 import { BaseIdTokenValidation } from './BaseIdTokenValidation';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKIDVA', error);
 
 /**
  * Class for id token validation for the Verifiable Credential attestation scenario
@@ -32,6 +34,7 @@ export class IdTokenValidation extends BaseIdTokenValidation {
       return {
         result: false,
         status: 500,
+        code: errorCode(1),
         detailedError: `Expected should have configuration issuers set for idToken`
       };
     }
@@ -44,6 +47,7 @@ export class IdTokenValidation extends BaseIdTokenValidation {
         return {
           result: false,
           status: 500,
+          code: errorCode(2),
           detailedError: `Expected should have configuration issuers set for idToken. Empty array presented.`
         };
       }
@@ -53,6 +57,7 @@ export class IdTokenValidation extends BaseIdTokenValidation {
         return {
           result: false,
           status: 500,
+          code: errorCode(3),
           detailedError: `The siopContract needs to be specified to validate the idTokens.`
         };
       }
@@ -62,6 +67,7 @@ export class IdTokenValidation extends BaseIdTokenValidation {
         return {
           result: false,
           status: 500,
+          code: errorCode(4),
           detailedError: `Expected should have configuration issuers set for idToken. Missing configuration for '${this.siopContract}'.`
         };
       }

--- a/lib/input_validation/LinkedDataCryptoSuitePublicKey.ts
+++ b/lib/input_validation/LinkedDataCryptoSuitePublicKey.ts
@@ -3,7 +3,10 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import base64url from 'base64url';
-const bs58 = require('bs58')
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+import ValidationError from '../error_handling/ValidationError';
+const bs58 = require('bs58');
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKLDCS', error);
 
 /**
  * Class to model the Linked Data crypto suites public keys
@@ -17,7 +20,7 @@ export default class LinkedDataCryptoSuitePublicKey {
     WorkEd25519VerificationKey2020: (rawPublicKey: any): object => {
       let publicKey = LinkedDataCryptoSuitePublicKey.parsePublicKey(rawPublicKey);
       if (!publicKey) {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(1));
       }
 
       if (typeof publicKey === 'string') {
@@ -35,7 +38,7 @@ export default class LinkedDataCryptoSuitePublicKey {
     Ed25519VerificationKey2018: (rawPublicKey: any): object => {
       let publicKey = LinkedDataCryptoSuitePublicKey.parsePublicKey(rawPublicKey);
       if (!publicKey) {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(3));
       }
 
       if (typeof publicKey === 'string') {
@@ -53,11 +56,11 @@ export default class LinkedDataCryptoSuitePublicKey {
     Secp256k1VerificationKey2018: (rawPublicKey: any): object => {
       let publicKey = LinkedDataCryptoSuitePublicKey.parsePublicKey(rawPublicKey);
       if (!publicKey) {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(5));
       }
 
       if (typeof publicKey === 'string') {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(4));
       }
 
       return publicKey;
@@ -65,11 +68,11 @@ export default class LinkedDataCryptoSuitePublicKey {
     EcdsaSecp256k1VerificationKey2019: (rawPublicKey: any): object => {
       let publicKey = LinkedDataCryptoSuitePublicKey.parsePublicKey(rawPublicKey);
       if (!publicKey) {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(7));
       }
 
       if (typeof publicKey === 'string') {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(6));
       }
 
       return publicKey;
@@ -77,11 +80,11 @@ export default class LinkedDataCryptoSuitePublicKey {
     RsaVerificationKey2018: (rawPublicKey: any): object => {
       let publicKey = LinkedDataCryptoSuitePublicKey.parsePublicKey(rawPublicKey);
       if (!publicKey) {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(9));
       }
 
       if (typeof publicKey === 'string') {
-        throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+        throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(8));
       }
 
       return publicKey;
@@ -95,17 +98,17 @@ export default class LinkedDataCryptoSuitePublicKey {
    */
   public static getPublicKey(rawPublicKey: any): any {
     if (!rawPublicKey) {
-      throw new Error(`The passed in public key is not defined`);
+      throw new ValidationError(`The passed in public key is not defined`, errorCode(10));
     }
 
     const suiteType = rawPublicKey.type;
     if (!suiteType) {
-      throw new Error(`The passed in public key has no type. ${JSON.stringify(rawPublicKey)}`);
+      throw new ValidationError(`The passed in public key has no type. ${JSON.stringify(rawPublicKey)}`, errorCode(11));
     }
 
     const suite = LinkedDataCryptoSuitePublicKey.suites[suiteType];
     if (!suite) {
-      throw new Error(`The suite with type: '${suiteType}' is not supported.`);
+      throw new ValidationError(`The suite with type: '${suiteType}' is not supported.`, errorCode(12));
     }
 
     return suite(rawPublicKey);
@@ -113,7 +116,7 @@ export default class LinkedDataCryptoSuitePublicKey {
 
   public static parsePublicKey(rawPublicKey: any): any {
     if (!rawPublicKey) {
-      throw new Error('Pass in the public key. Undefined.');
+      throw new ValidationError(`Pass in the public key. Undefined.`, errorCode(13));
     }
 
     let publicKey: any;
@@ -125,7 +128,7 @@ export default class LinkedDataCryptoSuitePublicKey {
       publicKey = base64url.encode(Buffer.from((rawPublicKey.publicKeyHex), 'hex'));
     }
     if (!publicKey) {
-      throw new Error(`${JSON.stringify(rawPublicKey)} public key type is not supported.`);
+      throw new ValidationError(`${JSON.stringify(rawPublicKey)} public key type is not supported.`, errorCode(2));
     }
 
     return publicKey;

--- a/lib/input_validation/SiopValidation.ts
+++ b/lib/input_validation/SiopValidation.ts
@@ -7,6 +7,8 @@ import { ISiopValidation, ISiopValidationResponse } from './SiopValidationRespon
 import { DidValidation } from './DidValidation';
 import { IValidationOptions } from '../options/IValidationOptions';
 import { IExpectedSiop } from '../index';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKSIVa', error);
 
 /**
  * Class for siop validation
@@ -55,6 +57,15 @@ export class SiopValidation implements ISiopValidation {
       return validationResponse;
     }
     
+    if (!validationResponse.tokenId) {
+      return {
+        result: false,
+        code: errorCode(1),
+        detailedError: `The SIOP token identifier (jti/id) is missing`,
+        status: 400
+      };    
+    }
+
     return validationResponse;
   }
 }

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -236,7 +236,7 @@ export class ValidationHelpers {
 
     //  use jwk in request if did is not registered
     if (!signingKey) {
-      throw new ValidationError(`The did '${did}' does not have a public key with kid '${kid}'. Public key : '${publicKey ? JSON.stringify(publicKey) : 'undefined'}'`, errorCode(1));
+      throw new ValidationError(`The did '${did}' does not have a public key with kid '${kid}'. Public key : '${publicKey ? JSON.stringify(publicKey) : 'undefined'}'`, errorCode(39));
     }
 
     return signingKey;
@@ -279,7 +279,7 @@ export class ValidationHelpers {
       if (current < nbf) {
         return {
           result: false,
-          code: errorCode(12),
+          code: errorCode(40),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is not yet valid ${nbf}`,
           status: 403
         };

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -68,7 +68,9 @@ export class ValidationHelpers {
       } catch (exception) {
         return {
           result: false,
+          code: errorCode(1),
           detailedError: `The ${(self as ValidationOptions).tokenType} could not be deserialized`,
+          innerError: exception,
           status: 400
         };
       }
@@ -77,6 +79,7 @@ export class ValidationHelpers {
     if (!validationResponse.didSignature) {
       return {
         result: false,
+        code: errorCode(2),
         detailedError: `The signature in the ${(self as ValidationOptions).tokenType} has an invalid format`,
         status: 403
       };
@@ -87,6 +90,7 @@ export class ValidationHelpers {
       if (!payload) {
         return {
           result: false,
+          code: errorCode(3),
           detailedError: `The payload in the ${(self as ValidationOptions).tokenType} is undefined`,
           status: 403
         };
@@ -98,6 +102,7 @@ export class ValidationHelpers {
         console.error(err);
         return {
           result: false,
+          code: errorCode(4),
           detailedError: `The payload in the ${(self as ValidationOptions).tokenType} is no valid JSON`,
           status: 400
         };
@@ -107,6 +112,7 @@ export class ValidationHelpers {
       if (!validationResponse.didKid) {
         return {
           result: false,
+          code: errorCode(5),
           detailedError: `The protected header in the ${(self as ValidationOptions).tokenType} does not contain the kid`,
           status: 403
         };
@@ -127,6 +133,7 @@ export class ValidationHelpers {
       if (!proof) {
         return {
           result: false,
+          code: errorCode(6),
           detailedError: `The proof is not available in the json ld payload`,
           status: 403
         };
@@ -134,6 +141,7 @@ export class ValidationHelpers {
       if (!proof.verificationMethod) {
         return {
           result: false,
+          code: errorCode(7),
           detailedError: `The proof does not contain the verificationMethod in the json ld payload`,
           status: 403
         };
@@ -160,6 +168,7 @@ export class ValidationHelpers {
       if (!resolveResult || !resolveResult.didDocument) {
         return validationResponse = {
           result: false,
+          code: errorCode(8),
           detailedError: `Could not retrieve DID document '${validationResponse.did}'`,
           status: 403
         }
@@ -170,8 +179,9 @@ export class ValidationHelpers {
       console.error(err);
       return {
         result: false,
+        code: errorCode(9),
+        innerError: err,
         detailedError: `Could not resolve DID '${validationResponse.did}'`,
-        code: err.code,
         status: 403
       };
     }
@@ -180,6 +190,7 @@ export class ValidationHelpers {
     if (!validationResponse.didKid) {
       return {
         result: false,
+        code: errorCode(10),
         detailedError: `The kid is not referenced in the request`,
         status: 403
       };
@@ -191,8 +202,9 @@ export class ValidationHelpers {
     } catch (exception) {
       return {
         result: false,
+        code: errorCode(11),
         detailedError: exception.message,
-        code: exception.code,
+        innerError: exception,
         status: 403
       };
     }
@@ -251,6 +263,7 @@ export class ValidationHelpers {
       if (current >= exp) {
         return {
           result: false,
+          code: errorCode(12),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is expired ${exp}, now ${current as number}`,
           status: 403
         };
@@ -266,6 +279,7 @@ export class ValidationHelpers {
       if (current < nbf) {
         return {
           result: false,
+          code: errorCode(12),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is not yet valid ${nbf}`,
           status: 403
         };
@@ -288,6 +302,7 @@ export class ValidationHelpers {
     if (!issuer) {
       return {
         result: false,
+        code: errorCode(13),
         detailedError: `The issuer in configuration was not found`,
         status: 403
       };
@@ -296,6 +311,7 @@ export class ValidationHelpers {
     if (!validationResponse.issuer) {
       return {
         result: false,
+        code: errorCode(14),
         detailedError: `Missing iss property in idToken. Expected '${JSON.stringify(issuer)}'`,
         status: 403
       };
@@ -304,6 +320,7 @@ export class ValidationHelpers {
     if (issuer !== validationResponse.issuer) {
       return {
         result: false,
+        code: errorCode(15),
         detailedError: `The issuer in configuration '${issuer}' does not correspond with the issuer in the payload ${validationResponse.issuer}`,
         status: 403
       };
@@ -314,6 +331,7 @@ export class ValidationHelpers {
       return {
         result: false,
         status: 401,
+        code: errorCode(16),
         detailedError: `The audience ${validationResponse.payloadObject.aud} is invalid`
       };
     }
@@ -335,6 +353,7 @@ export class ValidationHelpers {
     if (!validationResponse.issuer) {
       return {
         result: false,
+        code: errorCode(17),
         detailedError: `Missing iss property in verifiablePresentation. Expected '${siopDid}'`,
         status: 403
       };
@@ -343,6 +362,7 @@ export class ValidationHelpers {
     if (siopDid && validationResponse.issuer !== siopDid) {
       return <IValidationResponse>{
         result: false,
+        code: errorCode(18),
         detailedError: `Wrong iss property in verifiablePresentation. Expected '${siopDid}'`,
         status: 403
       };
@@ -353,6 +373,7 @@ export class ValidationHelpers {
       if (!validationResponse.payloadObject.aud) {
         return {
           result: false,
+          code: errorCode(19),
           detailedError: `Missing aud property in verifiablePresentation. Expected '${expected.didAudience}'`,
           status: 403
         };
@@ -361,6 +382,7 @@ export class ValidationHelpers {
       if (validationResponse.payloadObject.aud !== expected.didAudience) {
         return {
           result: false,
+          code: errorCode(20),
           detailedError: `Wrong aud property in verifiablePresentation. Expected '${expected.didAudience}'. Found '${validationResponse.payloadObject.aud}'`,
           status: 403
         };
@@ -384,6 +406,7 @@ export class ValidationHelpers {
     if (!validationResponse.payloadObject.sub) {
       return {
         result: false,
+        code: errorCode(21),
         detailedError: `Missing sub property in verifiableCredential. Expected '${siopDid}'`,
         status: 403
       };
@@ -393,6 +416,7 @@ export class ValidationHelpers {
     if (siopDid && validationResponse.payloadObject.sub !== siopDid) {
       return {
         result: false,
+        code: errorCode(22),
         detailedError: `Wrong sub property in verifiableCredential. Expected '${siopDid}'`,
         status: 403
       };
@@ -425,6 +449,7 @@ export class ValidationHelpers {
     if (!validationResponse.issuer) {
       return validationResponse = {
         result: false,
+        code: errorCode(23),
         detailedError: `Missing iss property in siop. Expected '${VerifiableCredentialConstants.TOKEN_SI_ISS}'`,
         status: 403
       };
@@ -433,6 +458,7 @@ export class ValidationHelpers {
     if (validationResponse.issuer !== VerifiableCredentialConstants.TOKEN_SI_ISS) {
       return validationResponse = {
         result: false,
+        code: errorCode(24),
         detailedError: `Wrong iss property in siop. Expected '${VerifiableCredentialConstants.TOKEN_SI_ISS}'`,
         status: 403
       };
@@ -442,6 +468,7 @@ export class ValidationHelpers {
     if (!validationResponse.payloadObject.aud) {
       return validationResponse = {
         result: false,
+        code: errorCode(25),
         detailedError: `Missing aud property in siop`,
         status: 403
       };
@@ -451,6 +478,7 @@ export class ValidationHelpers {
       if (validationResponse.payloadObject.aud !== expected.audience) {
         return validationResponse = {
           result: false,
+          code: errorCode(26),
           detailedError: `Wrong aud property in siop. Expected '${expected.audience}'`,
           status: 403
         };
@@ -474,6 +502,7 @@ export class ValidationHelpers {
       if (!validation) {
         return validationResponse = {
           result: false,
+          code: errorCode(27),
           detailedError: `The signature on the payload in the ${(self as ValidationOptions).tokenType} is invalid`,
           status: 403
         };
@@ -482,7 +511,9 @@ export class ValidationHelpers {
       console.error(err);
       return validationResponse = {
         result: false,
+        code: errorCode(28),
         detailedError: `Failed to validate signature`,
+        innerError: err,
         status: 403
       };
     }
@@ -512,6 +543,7 @@ export class ValidationHelpers {
           return {
             result: false,
             status: 403,
+            code: errorCode(29),
             detailedError: `Could not fetch token configuration needed to validate token`
           };
         }
@@ -523,6 +555,7 @@ export class ValidationHelpers {
           return {
             result: false,
             status: 403,
+            code: errorCode(30),
             detailedError: `No reference to jwks found in token configuration`
           };
         }
@@ -537,6 +570,7 @@ export class ValidationHelpers {
           return {
             result: false,
             status: 403,
+            code: errorCode(31),
             detailedError: `Could not fetch keys needed to validate token on '${keysUrl}'`
           };
         }
@@ -547,6 +581,7 @@ export class ValidationHelpers {
           return {
             result: false,
             status: 403,
+            code: errorCode(32),
             detailedError: `No or bad jwks keys found in token configuration`
           };
         }
@@ -557,6 +592,7 @@ export class ValidationHelpers {
           return {
             result: false,
             status: 403,
+            code: errorCode(33),
             detailedError: `No issuer found in token configuration`
           };
         }
@@ -566,6 +602,8 @@ export class ValidationHelpers {
       return {
         result: false,
         status: 403,
+        innerError: err,
+        code: errorCode(34),
         detailedError: `Could not fetch token configuration`
       };
     }
@@ -623,6 +661,7 @@ export class ValidationHelpers {
           return {
             result: false,
             status: 403,
+            code: errorCode(35),
             detailedError: `Could not validate token signature`
           };
         }
@@ -638,6 +677,8 @@ export class ValidationHelpers {
       return {
         result: false,
         status: 403,
+        code: errorCode(36),
+        innerError: err,
         detailedError: `Could not validate signature on id token`
       };
     }
@@ -659,6 +700,7 @@ export class ValidationHelpers {
       if (!validation) {
         return {
           result: false,
+          code: errorCode(37),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is has an invalid signature`,
           status: 403
         };
@@ -671,7 +713,9 @@ export class ValidationHelpers {
       console.error(err);
       return {
         result: false,
+        code: errorCode(38),
         detailedError: `Failed to verify token signature`,
+        innerError: err,
         status: 403
       };
     }

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -15,7 +15,7 @@ import { IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpect
 import LinkedDataCryptoSuitePublicKey from './LinkedDataCryptoSuitePublicKey';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
 import ValidationError from '../error_handling/ValidationError';
-const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVAHE', error);
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVaHe', error);
 
 require('es6-promise').polyfill();
 require('isomorphic-fetch');

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -103,6 +103,7 @@ export class ValidationHelpers {
         return {
           result: false,
           code: errorCode(4),
+          innerError: err,
           detailedError: `The payload in the ${(self as ValidationOptions).tokenType} is no valid JSON`,
           status: 400
         };

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -13,6 +13,9 @@ import { IdTokenValidationResponse } from './IdTokenValidationResponse';
 import { IValidationResponse } from './IValidationResponse';
 import { IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSiop, IExpectedAudience } from '../options/IExpected';
 import LinkedDataCryptoSuitePublicKey from './LinkedDataCryptoSuitePublicKey';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+import ValidationError from '../error_handling/ValidationError';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVAHE', error);
 
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
@@ -168,6 +171,7 @@ export class ValidationHelpers {
       return {
         result: false,
         detailedError: `Could not resolve DID '${validationResponse.did}'`,
+        code: err.code,
         status: 403
       };
     }
@@ -188,6 +192,7 @@ export class ValidationHelpers {
       return {
         result: false,
         detailedError: exception.message,
+        code: exception.code,
         status: 403
       };
     }
@@ -219,7 +224,7 @@ export class ValidationHelpers {
 
     //  use jwk in request if did is not registered
     if (!signingKey) {
-      throw new Error(`The did '${did}' does not have a public key with kid '${kid}'. Public key : '${publicKey ? JSON.stringify(publicKey) : 'undefined'}'`);
+      throw new ValidationError(`The did '${did}' does not have a public key with kid '${kid}'. Public key : '${publicKey ? JSON.stringify(publicKey) : 'undefined'}'`, errorCode(1));
     }
 
     return signingKey;

--- a/lib/input_validation/ValidationQueueItem.ts
+++ b/lib/input_validation/ValidationQueueItem.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import ErrorHelpers from '../error_handling/ErrorHelpers';
 import { ClaimToken } from '../index';
 import { IValidationResponse } from './IValidationResponse';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKQuIt', error);
 
 export enum ValidationStatus {
   /**
@@ -33,6 +35,7 @@ export default class ValidationQueueItem {
     this._validationResult = {
       result: false,
       status: 500,
+      code: errorCode(1),
       detailedError: 'Token not validated'
     };
   }

--- a/lib/input_validation/VerifiableCredentialValidation.ts
+++ b/lib/input_validation/VerifiableCredentialValidation.ts
@@ -5,8 +5,10 @@
 import { IValidationOptions } from '../options/IValidationOptions';
 import { IVerifiableCredentialValidation, VerifiableCredentialValidationResponse } from './VerifiableCredentialValidationResponse';
 import { DidValidation } from './DidValidation';
-import { IExpectedVerifiableCredential, ClaimToken } from '../index';
+import { IExpectedVerifiableCredential, ClaimToken, ValidationError } from '../index';
 import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVCVA', error);
 
 /**
  * Class for verifiable credential validation
@@ -79,6 +81,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       return {
         result: false,
         detailedError: exception.message,
+        code: exception.code,
         status: 403
       };
     }
@@ -156,15 +159,15 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
 
     const types: string[] = vc.type;
     if (!types || types.length === 0) {
-      throw new Error(`The vc property does not contain type`);
+      throw new ValidationError(`The vc property does not contain type`, errorCode(1));
     }
 
     if (types.length < 2) {
-      throw new Error(`The verifiable credential type property should have two elements`);
+      throw new ValidationError(`The verifiable credential type property should have two elements`, errorCode(2));
     }
 
     if (types[0] !== VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_TYPE) {
-      throw new Error(`The verifiable credential type first element should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_TYPE}`);
+      throw new ValidationError(`The verifiable credential type first element should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_TYPE}`, errorCode(3));
     }
 
     // Get credential type from context

--- a/lib/input_validation/VerifiableCredentialValidation.ts
+++ b/lib/input_validation/VerifiableCredentialValidation.ts
@@ -48,6 +48,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       if (!validationResponse.payloadObject.vc) {
         return {
           result: false,
+          code: errorCode(4),
           detailedError: `The verifiable credential vc property does not exist`,
           status: 403
         };
@@ -59,6 +60,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
     if (!context || context.length === 0) {
       return {
         result: false,
+        code: errorCode(5),
         detailedError: `The verifiable credential vc property does not contain ${VerifiableCredentialConstants.CLAIM_CONTEXT}`,
         status: 403
       };
@@ -67,6 +69,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
     if (context[0] !== VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_CONTEXT) {
       return {
         result: false,
+        code: errorCode(6),
         detailedError: `The verifiable credential context first element should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_CONTEXT}`,
         status: 403
       };
@@ -80,8 +83,9 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       console.error(exception.message);
       return {
         result: false,
+        code: errorCode(7),
         detailedError: exception.message,
-        code: exception.code,
+        innerError: exception,
         status: 403
       };
     }
@@ -90,6 +94,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
     if (!validationResponse.payloadObject.credentialSubject) {
       return {
         result: false,
+        code: errorCode(8),
         detailedError: `The verifiable credential with type '${credentialType}' does not has a credentialSubject property`,
         status: 403
       };
@@ -100,6 +105,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       if (!validationResponse.subject) {
         return {
           result: false,
+          code: errorCode(9),
           detailedError: `Missing sub property in verifiableCredential. Expected '${siopDid}'`,
           status: 403
         };
@@ -109,6 +115,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       if (siopDid && validationResponse.subject !== siopDid) {
         return {
           result: false,
+          code: errorCode(10),
           detailedError: `Wrong sub property in verifiableCredential. Expected '${siopDid}'`,
           status: 403
         };
@@ -123,6 +130,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       if (!subjects.includes(siopDid)) {
         return {
           result: false,
+          code: errorCode(11),
           detailedError: `The verifiable credential with type '${credentialType}', the id in the credentialSubject property does not match the presenter DID: ${siopDid}`,
           status: 403
         };
@@ -142,6 +150,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       if (!vcIssuers.includes(validationResponse.issuer!)) {
         return {
           result: false,
+          code: errorCode(12),
           detailedError: `The verifiable credential with type '${credentialType}' is not from a trusted issuer '${JSON.stringify(this.expected.contractIssuers)}'`,
           status: 403
         };
@@ -184,6 +193,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       return {
         result: false,
         status: 500,
+        code: errorCode(13),
         detailedError: `Expected should have contractIssuers set for verifyableCredential`
       };
     }
@@ -196,6 +206,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
         return {
           result: false,
           status: 500,
+          code: errorCode(14),
           detailedError: `Expected should have contractIssuers set for verifiableCredential. Empty array presented.`
         };
       }
@@ -205,6 +216,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
         return {
           result: false,
           status: 500,
+          code: errorCode(15),
           detailedError: `The credentialType needs to be specified to validate the verifiableCredential.`
         };
       }
@@ -214,6 +226,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
         return {
           result: false,
           status: 403,
+          code: errorCode(16),
           detailedError: `Expected should have contractIssuers set for verifiableCredential. Missing contractIssuers for '${credentialType}'.`
         };
       }

--- a/lib/input_validation/VerifiableCredentialValidationJsonLd.ts
+++ b/lib/input_validation/VerifiableCredentialValidationJsonLd.ts
@@ -51,6 +51,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
     if (!context || context.length === 0) {
       return {
         result: false,
+        code: errorCode(4),
         detailedError: `The verifiable credential vc property does not contain ${VerifiableCredentialConstants.CLAIM_CONTEXT}`,
         status: 403
       };
@@ -59,6 +60,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
     if (context[0] !== VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_CONTEXT) {
       return {
         result: false,
+        code: errorCode(5),
         detailedError: `The verifiable credential context first element should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_CONTEXT}`,
         status: 403
       };
@@ -72,8 +74,9 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
       console.error(exception.message);
       return {
         result: false,
+        code: errorCode(5),
         detailedError: exception.message,
-        code: exception.code,
+        innerError: exception,
         status: 403
       };
     }
@@ -82,6 +85,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
     if (!validationResponse.payloadObject.credentialSubject) {
       return {
         result: false,
+        code: errorCode(6),
         detailedError: `The verifiable credential with type '${credentialType}' does not has a credentialSubject property`,
         status: 403
       };
@@ -103,6 +107,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
       if (!subjects.includes(siopDid)) {
         return {
           result: false,
+          code: errorCode(7),
           detailedError: `The verifiable credential with type '${credentialType}', the id in the credentialSubject property does not match the presenter DID: ${siopDid}`,
           status: 403
         };
@@ -122,6 +127,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
       if (!contractIssuers) {
         return {
           result: false,
+          code: errorCode(8),
           detailedError: `The verifiable credential with type '${credentialType}' is not expected in '${JSON.stringify(this.expected.contractIssuers)}'`,
           status: 403
         };
@@ -130,6 +136,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
       if (!contractIssuers.includes(validationResponse.issuer!)) {
         return {
           result: false,
+          code: errorCode(9),
           detailedError: `The verifiable credential with type '${credentialType}' is not from a trusted issuer '${JSON.stringify(this.expected.contractIssuers)}'`,
           status: 403
         };
@@ -172,6 +179,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
       return {
         result: false,
         status: 500,
+        code: errorCode(10),
         detailedError: `Expected should have contractIssuers set for verifyableCredential`
       };
     }
@@ -184,6 +192,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
         return {
           result: false,
           status: 500,
+          code: errorCode(11),
           detailedError: `Expected should have contractIssuers set for verifiableCredential. Empty array presented.`
         };
       }
@@ -193,6 +202,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
         return {
           result: false,
           status: 500,
+          code: errorCode(12),
           detailedError: `The credentialType needs to be specified to validate the verifiableCredential.`
         };
       }
@@ -202,6 +212,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
         return {
           result: false,
           status: 403,
+          code: errorCode(13),
           detailedError: `Expected should have contractIssuers set for verifiableCredential. Missing contractIssuers for '${credentialType}'.`
         };
       }

--- a/lib/input_validation/VerifiableCredentialValidationJsonLd.ts
+++ b/lib/input_validation/VerifiableCredentialValidationJsonLd.ts
@@ -5,9 +5,10 @@
 import { IValidationOptions } from '../options/IValidationOptions';
 import { IVerifiableCredentialValidation, VerifiableCredentialValidationResponse } from './VerifiableCredentialValidationResponse';
 import { DidValidation } from './DidValidation';
-import { IExpectedVerifiableCredential, ClaimToken, VerifiableCredentialValidation } from '../index';
+import { IExpectedVerifiableCredential, ClaimToken, VerifiableCredentialValidation, ValidationError } from '../index';
 import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
-import { isContext } from 'vm';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVCLD', error);
 
 /**
  * Class for verifiable credential validation
@@ -145,15 +146,15 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
 
     const types: string[] = vc.type;
     if (!types || types.length === 0) {
-      throw new Error(`The vc property does not contain type`);
+      throw new ValidationError(`The vc property does not contain type`, errorCode(1));
     }
 
     if (types.length < 2) {
-      throw new Error(`The verifiable credential type property should have two elements`);
+      throw new ValidationError(`The verifiable credential type property should have two elements`, errorCode(2));
     }
 
     if (types[0] !== VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_TYPE) {
-      throw new Error(`The verifiable credential type first element should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_TYPE}`);
+      throw new ValidationError(`The verifiable credential type first element should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLECREDENTIAL_TYPE}`, errorCode(3));
     }
 
     // Get credential type from context

--- a/lib/input_validation/VerifiableCredentialValidationJsonLd.ts
+++ b/lib/input_validation/VerifiableCredentialValidationJsonLd.ts
@@ -73,6 +73,7 @@ export class VerifiableCredentialValidationJsonLd implements IVerifiableCredenti
       return {
         result: false,
         detailedError: exception.message,
+        code: exception.code,
         status: 403
       };
     }

--- a/lib/input_validation/VerifiablePresentationValidation.ts
+++ b/lib/input_validation/VerifiablePresentationValidation.ts
@@ -4,12 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 import { VerifiablePresentationValidationResponse, IVerifiablePresentationValidation } from './VerifiablePresentationValidationResponse';
 import { IValidationOptions } from '../options/IValidationOptions';
-import ClaimToken from '../verifiable_credential/ClaimToken';
 import { DidValidation } from './DidValidation';
 import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
 import { IExpectedVerifiablePresentation } from '../index';
-import { Crypto } from '../index';
-import { KeyStoreOptions, JsonWebKey } from 'verifiablecredentials-crypto-sdk-typescript';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVPVa', error);
 
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
@@ -58,6 +57,7 @@ export class VerifiablePresentationValidation implements IVerifiablePresentation
     if (this.siopDid && validationResponse.did !== this.siopDid) {
       return {
         result: false,
+        code: errorCode(1),
         detailedError: `The DID used for the SIOP ${this.siopDid} is not equal to the DID used for the verifiable presentation ${validationResponse.did}`,
         status: 403
       };
@@ -67,6 +67,7 @@ export class VerifiablePresentationValidation implements IVerifiablePresentation
       return {
         result: false,
         status: 403,
+        code: errorCode(2),
         detailedError: `Missing vp in presentation`
       };
     }
@@ -75,6 +76,7 @@ export class VerifiablePresentationValidation implements IVerifiablePresentation
       return {
         result: false,
         status: 403,
+        code: errorCode(3),
         detailedError: `Missing @context in presentation`
       };
     }
@@ -83,6 +85,7 @@ export class VerifiablePresentationValidation implements IVerifiablePresentation
       return {
         result: false,
         status: 403,
+        code: errorCode(3),
         detailedError: `Missing or wrong default type in vp of presentation. Should be ${VerifiableCredentialConstants.DEFAULT_VERIFIABLEPRESENTATION_TYPE}`
       };
     }
@@ -90,6 +93,7 @@ export class VerifiablePresentationValidation implements IVerifiablePresentation
       return {
         result: false,
         status: 403,
+        code: errorCode(4),
         detailedError: `Missing verifiableCredential in presentation`
       };
     }

--- a/lib/resolver/ManagedHttpResolver.ts
+++ b/lib/resolver/ManagedHttpResolver.ts
@@ -1,6 +1,9 @@
-import { DidDocument, IDidResolver, IDidResolveResult } from '../index';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+import { DidDocument, IDidResolver, IDidResolveResult, ValidationError } from '../index';
 import FetchRequest from '../tracing/FetchRequest';
 import IFetchRequest from '../tracing/IFetchRequest';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKMARE', error);
+
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
 
@@ -49,6 +52,7 @@ export default class ManagedHttpResolver implements IDidResolver {
         metadata: didDocument.resolverMetadata
       } as IDidResolveResult;
     }
-    return Promise.reject(new Error(`Could not resolve ${query}`));
+    
+    return Promise.reject(new ValidationError(`Could not resolve ${query}`, errorCode(1)));
   }
 }

--- a/lib/verifiable_credential/ClaimToken.ts
+++ b/lib/verifiable_credential/ClaimToken.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import base64url from 'base64url';
 import VerifiableCredentialConstants from './VerifiableCredentialConstants';
-import { PresentationDefinitionModel, ValidationError } from '../index';
-import { ErrorHelpers } from '../error_handling/ErrorHelpers';
+import ValidationError from '../error_handling/ValidationError';
+import { PresentationDefinitionModel  } from '../index';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
 const jp = require('jsonpath');
 const errorCode = (error: number) => ErrorHelpers.errorCode('CLTO', error);
 
@@ -214,8 +215,8 @@ export default class ClaimToken {
   * This algorithm will convert the attestations to a ClaimToken
   * @param payload The presentaiton exchange payload 
   */
-  public static getClaimTokensFromPresentationExchange(payload: PresentationDefinitionModel): { [key: string]: ClaimToken } {
-    const decodedTokens: { [key: string]: ClaimToken } = {};
+ public static getClaimTokensFromPresentationExchange(payload: PresentationDefinitionModel): { [key: string]: ClaimToken } {
+  const decodedTokens: { [key: string]: ClaimToken } = {};
     // Get descriptor map
     const descriptorMap: any[] = jp.query(payload, `$.presentation_submission.descriptor_map.*`);
 

--- a/lib/verifiable_credential/ClaimToken.ts
+++ b/lib/verifiable_credential/ClaimToken.ts
@@ -8,7 +8,7 @@ import ValidationError from '../error_handling/ValidationError';
 import { PresentationDefinitionModel  } from '../index';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
 const jp = require('jsonpath');
-const errorCode = (error: number) => ErrorHelpers.errorCode('CLTO', error);
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKCLTO', error);
 
 /**
  * Enum for define the token type

--- a/lib/verifiable_credential/ClaimToken.ts
+++ b/lib/verifiable_credential/ClaimToken.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 import base64url from 'base64url';
 import VerifiableCredentialConstants from './VerifiableCredentialConstants';
-import { PresentationDefinitionModel } from '..';
+import { PresentationDefinitionModel, ValidationError } from '../index';
+import { ErrorHelpers } from '../error_handling/ErrorHelpers';
 const jp = require('jsonpath');
+const errorCode = (error: number) => ErrorHelpers.errorCode('CLTO', error);
 
 /**
  * Enum for define the token type
@@ -121,7 +123,7 @@ export default class ClaimToken {
     if (tokentypeValues.includes(typeName)) {
       this._type = typeName as TokenType;
     } else {
-      throw new Error(`Type '${typeName}' is not supported`);
+      throw new ValidationError(`Type '${typeName}' is not supported`, errorCode(1));
     }
 
     if (typeof token === 'string') {
@@ -221,13 +223,13 @@ export default class ClaimToken {
       const item = descriptorMap[inx];
       if (item) {
         if (!item.id) {
-          throw new Error(`The SIOP presentation exchange response has descriptor_map without id property`);
+          throw new ValidationError(`The SIOP presentation exchange response has descriptor_map without id property`, errorCode(2));
         } else if (item.path) {
           const tokenFinder = jp.query(payload, item.path);
           if (tokenFinder.length == 0) {
-            throw new Error(`The SIOP presentation exchange response has descriptor_map with id '${item.id}'. This path '${item.path}' did not return a token.`);
+            throw new ValidationError(`The SIOP presentation exchange response has descriptor_map with id '${item.id}'. This path '${item.path}' did not return a token.`, errorCode(3));
           } else if (tokenFinder.length > 1) {
-            throw new Error(`The SIOP presentation exchange response has descriptor_map with id '${item.id}'. This path '${item.path}' points to multiple credentails and should only point to one credential.`);
+            throw new ValidationError(`The SIOP presentation exchange response has descriptor_map with id '${item.id}'. This path '${item.path}' points to multiple credentails and should only point to one credential.`, errorCode(4));
           } else if (typeof tokenFinder[0] === 'string') {
             const foundToken = tokenFinder[0];
             const claimToken = ClaimToken.create(foundToken);
@@ -238,7 +240,7 @@ export default class ClaimToken {
             decodedTokens[item.id] = claimToken;
           }
         } else {
-          throw new Error(`The SIOP presentation exchange response has descriptor_map with id '${item.id}'. No path property found.`);
+          throw new ValidationError(`The SIOP presentation exchange response has descriptor_map with id '${item.id}'. No path property found.`, errorCode(5));
         }
       }
     }
@@ -254,7 +256,7 @@ export default class ClaimToken {
   private decode(): void {
     const parts = (<string>this.rawToken).split('.');
     if (parts.length < 2) {
-      throw new Error(`Cannot decode. Invalid input token`);
+      throw new ValidationError(`Cannot decode. Invalid input token`, errorCode(6));
     }
 
     this._tokenHeader = JSON.parse(base64url.decode(parts[0]));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.11.1",
+  "version": "0.12.1-preview.0",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
@@ -45,7 +45,7 @@
     "clone": "2.1.2",
     "deep-property-access": "1.0.1",
     "es6-promise": "^4.2.8",
-    "isomorphic-fetch": "2.2.1",
+    "isomorphic-fetch": "3.0.0",
     "jsonpath": "1.0.2",
     "multihashes": "0.4.14",
     "uuid": "7.0.1",

--- a/tests/ClaimToken.spec.ts
+++ b/tests/ClaimToken.spec.ts
@@ -40,7 +40,7 @@ import { ValidationError } from '../lib';
     expect(claimToken.rawToken).toEqual('1');
 
     // negative cases
-    expect(() => new ClaimToken(<any>'', token, configuration)).toThrowMatching((exception) => exception.message === `Type '' is not supported` && exception.code === 'CLTO01');
-    expect(() => new ClaimToken(TokenType.siopIssuance, 'token')).toThrowMatching((exception) => exception.message === `Cannot decode. Invalid input token` && exception.code === 'CLTO06');
+    expect(() => new ClaimToken(<any>'', token, configuration)).toThrowMatching((exception) => exception.message === `Type '' is not supported` && exception.code === 'VCSDKCLTO01');
+    expect(() => new ClaimToken(TokenType.siopIssuance, 'token')).toThrowMatching((exception) => exception.message === `Cannot decode. Invalid input token` && exception.code === 'VCSDKCLTO06');
   });
  });

--- a/tests/ClaimToken.spec.ts
+++ b/tests/ClaimToken.spec.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import ClaimToken, { TokenType } from '../lib/verifiable_credential/ClaimToken';
 import base64url from 'base64url';
+import { ValidationError } from '../lib';
 
  describe('ClaimToken', () => {
   it ('should create a ClaimToken', () => {
@@ -39,7 +40,7 @@ import base64url from 'base64url';
     expect(claimToken.rawToken).toEqual('1');
 
     // negative cases
-    expect(() => new ClaimToken(<any>'', token, configuration)).toThrowError(`Type '' is not supported`);
-    expect(() => new ClaimToken(TokenType.siopIssuance, 'token')).toThrowError('Cannot decode. Invalid input token');
+    expect(() => new ClaimToken(<any>'', token, configuration)).toThrowMatching((exception) => exception.message === `Type '' is not supported` && exception.code === 'CLTO01');
+    expect(() => new ClaimToken(TokenType.siopIssuance, 'token')).toThrowMatching((exception) => exception.message === `Cannot decode. Invalid input token` && exception.code === 'CLTO06');
   });
  });

--- a/tests/DidValidation.spec.ts
+++ b/tests/DidValidation.spec.ts
@@ -35,7 +35,7 @@ describe('DidValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the siopIssuance is invalid');
-    expect(response.code).toEqual('VCSDKVAHE27');
+    expect(response.code).toEqual('VCSDKVaHe27');
 
     // invalid format
     let tokenParts =  (<string>request.rawToken).split('.');
@@ -43,7 +43,7 @@ describe('DidValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(400);
     expect(response.detailedError).toEqual('The siopIssuance could not be deserialized');
-    expect(response.code).toEqual('VCSDKVAHE01');
+    expect(response.code).toEqual('VCSDKVaHe01');
 
     // Token has no kid
     let header: any = {
@@ -55,7 +55,7 @@ describe('DidValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The protected header in the siopIssuance does not contain the kid');
-    expect(response.code).toEqual('VCSDKVAHE05');
+    expect(response.code).toEqual('VCSDKVaHe05');
 
     // The kid has no did
     header = {

--- a/tests/DidValidation.spec.ts
+++ b/tests/DidValidation.spec.ts
@@ -35,6 +35,7 @@ describe('DidValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the siopIssuance is invalid');
+    expect(response.code).toEqual('VCSDKVAHE27');
 
     // invalid format
     let tokenParts =  (<string>request.rawToken).split('.');
@@ -53,6 +54,7 @@ describe('DidValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The protected header in the siopIssuance does not contain the kid');
+    expect(response.code).toEqual('VCSDKVAHE05');
 
     // The kid has no did
     header = {
@@ -65,6 +67,7 @@ describe('DidValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The kid in the protected header does not contain the DID. Required format for kid is <did>#kid');
+    expect(response.code).toEqual('VCSDKDIDV01');
 
     // failing token time
     options.checkTimeValidityOnTokenDelegate= () => {
@@ -89,6 +92,7 @@ describe('DidValidation', () =>
     response = await validator.validate(<string>request.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('The kid does not contain the DID');
+    expect(response.code).toEqual('VCSDKDIDV02');
 
     // failing DID resolve
     setup.fetchMock.reset();

--- a/tests/DidValidation.spec.ts
+++ b/tests/DidValidation.spec.ts
@@ -43,6 +43,7 @@ describe('DidValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(400);
     expect(response.detailedError).toEqual('The siopIssuance could not be deserialized');
+    expect(response.code).toEqual('VCSDKVAHE01');
 
     // Token has no kid
     let header: any = {

--- a/tests/ErrorHelpers.spec.ts
+++ b/tests/ErrorHelpers.spec.ts
@@ -3,10 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ErrorHelpers } from "../lib/error_handling/ErrorHelpers";
+import ErrorHelpers from "../lib/error_handling/ErrorHelpers";
 
  describe('ErrorHelpers', () => {
   it('should return the correct error code', () => {
     expect(ErrorHelpers.errorCode('ABC', 5)).toEqual('ABC05');
+    expect(ErrorHelpers.errorCode('ABC', 15)).toEqual('ABC15');
+    expect(ErrorHelpers.errorCode('ABC', 15, 1)).toEqual('ABC15');
+    expect(ErrorHelpers.errorCode('ABC', 15, 4)).toEqual('ABC0015');
   });
  });

--- a/tests/ErrorHelpers.spec.ts
+++ b/tests/ErrorHelpers.spec.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ErrorHelpers } from "../lib/error_handling/ErrorHelpers";
+
+ describe('ErrorHelpers', () => {
+  it('should return the correct error code', () => {
+    expect(ErrorHelpers.errorCode('ABC', 5)).toEqual('ABC05');
+  });
+ });

--- a/tests/IdTokenValidation.spec.ts
+++ b/tests/IdTokenValidation.spec.ts
@@ -43,7 +43,7 @@ import { IExpectedIdToken, Validator } from '../lib';
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(400);
     expect(response.detailedError).toEqual('The idToken could not be deserialized');
-    expect(response.code).toEqual('VCSDKVAHE01');
+    expect(response.code).toEqual('VCSDKVaHe01');
 
     // Bad id token signature
     validator = new IdTokenValidation(options, expected, Validator.readContractId(siop.contract));
@@ -51,35 +51,35 @@ import { IExpectedIdToken, Validator } from '../lib';
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The presented idToken is has an invalid signature');
-    expect(response.code).toEqual('VCSDKVAHE37');
+    expect(response.code).toEqual('VCSDKVaHe37');
 
     // missing siopcontract
     validator = new IdTokenValidation(options, <any>{configuration: {} }, <any>undefined);
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('The siopContract needs to be specified to validate the idTokens.');
-    expect(response.code).toEqual('VCSDKIDVA03');
+    expect(response.code).toEqual('VCSDKIDVa03');
 
     // missing configuration array in expected
     validator = new IdTokenValidation(options, <any>{configuration: {} }, Validator.readContractId(siop.contract));
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual(`Expected should have configuration issuers set for idToken. Missing configuration for 'schema'.`);
-    expect(response.code).toEqual('VCSDKIDVA04');
+    expect(response.code).toEqual('VCSDKIDVa04');
 
     // empty array in configuration
     validator = new IdTokenValidation(options, <any>{configuration: [] }, Validator.readContractId(siop.contract));
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('Expected should have configuration issuers set for idToken. Empty array presented.');
-    expect(response.code).toEqual('VCSDKIDVA02');
+    expect(response.code).toEqual('VCSDKIDVa02');
 
     // missing configuration in expected
     validator = new IdTokenValidation(options, <any>{}, Validator.readContractId(siop.contract));
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('Expected should have configuration issuers set for idToken');
-    expect(response.code).toEqual('VCSDKIDVA01');
+    expect(response.code).toEqual('VCSDKIDVa01');
 
     // todo fix aud
     return;

--- a/tests/IdTokenValidation.spec.ts
+++ b/tests/IdTokenValidation.spec.ts
@@ -50,30 +50,35 @@ import { IExpectedIdToken, Validator } from '../lib';
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The presented idToken is has an invalid signature');
+    expect(response.code).toEqual('VCSDKVAHE37');
 
     // missing siopcontract
     validator = new IdTokenValidation(options, <any>{configuration: {} }, <any>undefined);
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('The siopContract needs to be specified to validate the idTokens.');
+    expect(response.code).toEqual('VCSDKIDVA03');
 
     // missing configuration array in expected
     validator = new IdTokenValidation(options, <any>{configuration: {} }, Validator.readContractId(siop.contract));
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual(`Expected should have configuration issuers set for idToken. Missing configuration for 'schema'.`);
+    expect(response.code).toEqual('VCSDKIDVA04');
 
     // empty array in configuration
     validator = new IdTokenValidation(options, <any>{configuration: [] }, Validator.readContractId(siop.contract));
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('Expected should have configuration issuers set for idToken. Empty array presented.');
+    expect(response.code).toEqual('VCSDKIDVA02');
 
     // missing configuration in expected
     validator = new IdTokenValidation(options, <any>{}, Validator.readContractId(siop.contract));
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('Expected should have configuration issuers set for idToken');
+    expect(response.code).toEqual('VCSDKIDVA01');
 
     // todo fix aud
     return;

--- a/tests/IdTokenValidation.spec.ts
+++ b/tests/IdTokenValidation.spec.ts
@@ -43,6 +43,7 @@ import { IExpectedIdToken, Validator } from '../lib';
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(400);
     expect(response.detailedError).toEqual('The idToken could not be deserialized');
+    expect(response.code).toEqual('VCSDKVAHE01');
 
     // Bad id token signature
     validator = new IdTokenValidation(options, expected, Validator.readContractId(siop.contract));

--- a/tests/LinkedDataCryptoSuitePublicKey.spec.ts
+++ b/tests/LinkedDataCryptoSuitePublicKey.spec.ts
@@ -28,17 +28,17 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
     expect(jwk.crv).toEqual('ed25519');
 
     // Negative cases
-    expect(() => suites.WorkEd25519VerificationKey2020(undefined)).toThrowError('Pass in the public key. Undefined.');
+    expect(() => suites.WorkEd25519VerificationKey2020(undefined)).toThrowMatching((exception) => exception.message === 'Pass in the public key. Undefined.' && exception.code === 'VCSDKLDCS13');
 
     const decodeBase58To64UrlSpy = spyOn(LinkedDataCryptoSuitePublicKey, 'decodeBase58To64Url').and.callFake((): string  => {
       return <any>undefined;
     });
-    expect(() => suites.WorkEd25519VerificationKey2020(didDocumentPublicKey)).toThrowError('{"@context":["https://w3id.org/security/v1"],"id":"did:example:123456789abcdefghi#keys-1","type":"Ed25519VerificationKey2018","controller":"did:example:123456789abcdefghi","expires":"2017-02-08T16:02:20Z","publicKeyBase58":"H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"} public key type is not supported.');
+    expect(() => suites.WorkEd25519VerificationKey2020(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `{"@context":["https://w3id.org/security/v1"],"id":"did:example:123456789abcdefghi#keys-1","type":"Ed25519VerificationKey2018","controller":"did:example:123456789abcdefghi","expires":"2017-02-08T16:02:20Z","publicKeyBase58":"H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"} public key type is not supported.` && exception.code === 'VCSDKLDCS02');
 
     let parsePublicKeySpy = spyOn(LinkedDataCryptoSuitePublicKey, 'parsePublicKey').and.callFake((): string  => {
       return <any>undefined;
     });
-    expect(() => suites.WorkEd25519VerificationKey2020(didDocumentPublicKey)).toThrowError('{"@context":["https://w3id.org/security/v1"],"id":"did:example:123456789abcdefghi#keys-1","type":"Ed25519VerificationKey2018","controller":"did:example:123456789abcdefghi","expires":"2017-02-08T16:02:20Z","publicKeyBase58":"H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"} public key type is not supported.');
+    expect(() => suites.WorkEd25519VerificationKey2020(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `{"@context":["https://w3id.org/security/v1"],"id":"did:example:123456789abcdefghi#keys-1","type":"Ed25519VerificationKey2018","controller":"did:example:123456789abcdefghi","expires":"2017-02-08T16:02:20Z","publicKeyBase58":"H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"} public key type is not supported.` && exception.code === 'VCSDKLDCS01');
     parsePublicKeySpy.and.callFake(() => {
       return { publicKey: 'some key'};
     });
@@ -94,7 +94,7 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
     expect(jwk.x).toEqual(base64url.encode(Buffer.from('1122334455', 'hex')));
 
     // Negative cases
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowError('The passed in public key is not defined');
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowMatching((exception) => exception.message === 'The passed in public key is not defined' && exception.code === 'VCSDKLDCS10');
 
     didDocumentPublicKey = {
       "@context": ["https://w3id.org/security/v1"],
@@ -103,12 +103,13 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
       "expires": "2017-02-08T16:02:20Z",
       "publicKeyHex": "1122334455"
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`The passed in public key has no type. {"@context":["https://w3id.org/security/v1"],"id":"did:example:123456789abcdefghi#keys-1","controller":"did:example:123456789abcdefghi","expires":"2017-02-08T16:02:20Z","publicKeyHex":"1122334455"}`);
-    expect(() => LinkedDataCryptoSuitePublicKey.parsePublicKey(<any>undefined)).toThrowError(`Pass in the public key. Undefined.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `The passed in public key has no type. {"@context":["https://w3id.org/security/v1"],"id":"did:example:123456789abcdefghi#keys-1","controller":"did:example:123456789abcdefghi","expires":"2017-02-08T16:02:20Z","publicKeyHex":"1122334455"}` && exception.code === 'VCSDKLDCS11');
+    expect(() => LinkedDataCryptoSuitePublicKey.parsePublicKey(<any>undefined)).toThrowMatching((exception) => exception.message === 'Pass in the public key. Undefined.' && exception.code === 'VCSDKLDCS13');
+
     didDocumentPublicKey = {
       "xxx": "1122334455"
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.parsePublicKey(didDocumentPublicKey)).toThrowError(`{"xxx":"1122334455"} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.parsePublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `{"xxx":"1122334455"} public key type is not supported.` && exception.code === 'VCSDKLDCS02');
 
     didDocumentPublicKey = {
       "@context": ["https://w3id.org/security/v1"],
@@ -118,14 +119,14 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
       "expires": "2017-02-08T16:02:20Z",
       "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`The suite with type: 'xxx' is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `The suite with type: 'xxx' is not supported.` && exception.code === 'VCSDKLDCS12');
 
     const testSpy = {
       "type": "Ed25519VerificationKey2018",
       "publicKeyJwk": {}
     };
     const parsePublicKeySpy: jasmine.Spy = spyOn(LinkedDataCryptoSuitePublicKey, 'parsePublicKey').withArgs(testSpy);
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowError(`{"type":"Ed25519VerificationKey2018","publicKeyJwk":{}} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowMatching((exception) => exception.message === `{"type":"Ed25519VerificationKey2018","publicKeyJwk":{}} public key type is not supported.` && exception.code === 'VCSDKLDCS03');
   });
   it('should return a Secp256k1VerificationKey2018 public key', () => {
     let didDocumentPublicKey: any = {
@@ -153,7 +154,7 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
     expect(jwk.y).toEqual('05fsHpcimSDwdnQ_sKw5tmsNMx_3WRBDibpydraxLwA');
 
     // Negative cases
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowError('The passed in public key is not defined');
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowMatching((exception) => exception.message === 'The passed in public key is not defined' && exception.code === 'VCSDKLDCS10');
     didDocumentPublicKey = {
       "id": "#test-key",
       "type": "xxx",
@@ -168,21 +169,22 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
         "defaultEncryptionAlgorithm": "none"
       }
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`The suite with type: 'xxx' is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `The suite with type: 'xxx' is not supported.` && exception.code === 'VCSDKLDCS12');
+
 
     didDocumentPublicKey = {
       "id": "#test-key",
       "type": "Secp256k1VerificationKey2018",
       "publicKeyBase58": "AAAAA"
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`{"id":"#test-key","type":"Secp256k1VerificationKey2018","publicKeyBase58":"AAAAA"} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `{"id":"#test-key","type":"Secp256k1VerificationKey2018","publicKeyBase58":"AAAAA"} public key type is not supported.` && exception.code === 'VCSDKLDCS04');
 
     const testSpy = {
       "type": "Secp256k1VerificationKey2018",
       "publicKeyJwk": {}
     };
     const parsePublicKeySpy: jasmine.Spy = spyOn(LinkedDataCryptoSuitePublicKey, 'parsePublicKey').withArgs(testSpy);
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowError(`{"type":"Secp256k1VerificationKey2018","publicKeyJwk":{}} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowMatching((exception) => exception.message === `{"type":"Secp256k1VerificationKey2018","publicKeyJwk":{}} public key type is not supported.` && exception.code === 'VCSDKLDCS05');
   });
   it('should return a EcdsaSecp256k1VerificationKey2019 public key', () => {
     let didDocumentPublicKey: any = {
@@ -216,8 +218,8 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
       "publicKeyBase58": "AAAAA"
     };
 
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`{"id":"#test-key","type":"EcdsaSecp256k1VerificationKey2019","publicKeyBase58":"AAAAA"} public key type is not supported.`);
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowError('The passed in public key is not defined');
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `{"id":"#test-key","type":"EcdsaSecp256k1VerificationKey2019","publicKeyBase58":"AAAAA"} public key type is not supported.` && exception.code === 'VCSDKLDCS06');
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowMatching((exception) => exception.message === 'The passed in public key is not defined' && exception.code === 'VCSDKLDCS10');
     didDocumentPublicKey = {
       "id": "#test-key",
       "type": "xxx",
@@ -232,21 +234,21 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
         "defaultEncryptionAlgorithm": "none"
       }
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`The suite with type: 'xxx' is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `The suite with type: 'xxx' is not supported.` && exception.code === 'VCSDKLDCS12');
 
     didDocumentPublicKey = {
       "id": "#test-key",
       "type": "EcdsaSecp256k1VerificationKey2019",
       "publicKeyBase58": "AAAAA"
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`{"id":"#test-key","type":"EcdsaSecp256k1VerificationKey2019","publicKeyBase58":"AAAAA"} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `{"id":"#test-key","type":"EcdsaSecp256k1VerificationKey2019","publicKeyBase58":"AAAAA"} public key type is not supported.` && exception.code === 'VCSDKLDCS06');
 
     const testSpy = {
       "type": "EcdsaSecp256k1VerificationKey2019",
       "publicKeyJwk": {}
     };
     const parsePublicKeySpy: jasmine.Spy = spyOn(LinkedDataCryptoSuitePublicKey, 'parsePublicKey').withArgs(testSpy);
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowError(`{"type":"EcdsaSecp256k1VerificationKey2019","publicKeyJwk":{}} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowMatching((exception) => exception.message === `{"type":"EcdsaSecp256k1VerificationKey2019","publicKeyJwk":{}} public key type is not supported.` && exception.code === 'VCSDKLDCS07');
   });
   it('should return a RsaVerificationKey2018 public key', () => {
     let didDocumentPublicKey: any = {
@@ -275,9 +277,9 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
       "type": "RsaVerificationKey2018",
       "publicKeyBase58": "AAAAA"
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`{"id":"#test-key","type":"RsaVerificationKey2018","publicKeyBase58":"AAAAA"} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `{"id":"#test-key","type":"RsaVerificationKey2018","publicKeyBase58":"AAAAA"} public key type is not supported.` && exception.code === 'VCSDKLDCS08');
 
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowError('The passed in public key is not defined');
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>undefined)).toThrowMatching((exception) => exception.message === 'The passed in public key is not defined' && exception.code === 'VCSDKLDCS10');
     didDocumentPublicKey = {
       "id": "#test-key",
       "type": "xxx",
@@ -289,14 +291,14 @@ describe('LinkedDataCryptoSuitePublicKey', () => {
         "use": "sig"
       }
     };
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowError(`The suite with type: 'xxx' is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(didDocumentPublicKey)).toThrowMatching((exception) => exception.message === `The suite with type: 'xxx' is not supported.` && exception.code === 'VCSDKLDCS12');
 
     const testSpy = {
       "type": "RsaVerificationKey2018",
       "publicKeyJwk": {}
     };
     const parsePublicKeySpy: jasmine.Spy = spyOn(LinkedDataCryptoSuitePublicKey, 'parsePublicKey').withArgs(testSpy);
-    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowError(`{"type":"RsaVerificationKey2018","publicKeyJwk":{}} public key type is not supported.`);
+    expect(() => LinkedDataCryptoSuitePublicKey.getPublicKey(<any>testSpy)).toThrowMatching((exception) => exception.message === `{"type":"RsaVerificationKey2018","publicKeyJwk":{}} public key type is not supported.` && exception.code === 'VCSDKLDCS09');
   });
 
 });

--- a/tests/ManagedHttpResolver.spec.ts
+++ b/tests/ManagedHttpResolver.spec.ts
@@ -51,7 +51,8 @@ const fetchMock = require('fetch-mock');
         await resolver.resolve('did', fetchRequest);
         fail('exception on resolve was  not thrown');
        } catch (exception) {
-         expect(exception).toEqual(new Error('Could not resolve https://resolver/did'));
-       }
+        expect(exception.message).toEqual('Could not resolve https://resolver/did');
+        expect(exception.code).toEqual('VCSDKMARE01');
+      }
     });
   });

--- a/tests/OpenIdTokenValidation.spec.ts
+++ b/tests/OpenIdTokenValidation.spec.ts
@@ -42,7 +42,7 @@ describe('OpenIdTokenValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The presented idToken is has an invalid signature');
-    expect(response.code).toEqual('VCSDKVAHE37');
+    expect(response.code).toEqual('VCSDKVaHe37');
   });
 
   it('should fail validation when the issuer is incorrect', async () => {

--- a/tests/OpenIdTokenValidation.spec.ts
+++ b/tests/OpenIdTokenValidation.spec.ts
@@ -42,6 +42,7 @@ describe('OpenIdTokenValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The presented idToken is has an invalid signature');
+    expect(response.code).toEqual('VCSDKVAHE37');
   });
 
   it('should fail validation when the issuer is incorrect', async () => {

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -18,13 +18,13 @@ const clone = require('clone');
 describe('PresentationExchange', () => {
   let model = new RequestOneVcResponseOk();
   let requestor = new RequestorHelper(model);
-  let responder: ResponderHelper;
+  let responderHelper: ResponderHelper;
 
   beforeAll(async () => {
     await requestor.setup();
 
-    responder = new ResponderHelper(requestor, model);
-    await responder.setup();
+    responderHelper = new ResponderHelper(requestor, model);
+    await responderHelper.setup();
   });
 
   afterAll(() => {
@@ -51,65 +51,65 @@ describe('PresentationExchange', () => {
     expect(request.rawToken).toBeDefined();
     console.log(request.rawToken);
 
-    let response = await responder.createResponse();
+    let responderResponse = await responderHelper.createResponse();
 
     let validator = new ValidatorBuilder(requestor.crypto)
-      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
+      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responderHelper.generator.crypto.builder.did!] })
       .build();
-    let result = await validator.validate(<string>response.rawToken);
-    expect(result.result).toBeTruthy(result.detailedError);
+    let response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.result).toBeTruthy(response.detailedError);
 
     // Negative cases
 
     //Remove presentation_submission
-    let responsePayload = clone(response.decodedToken);
+    let responsePayload = clone(responderResponse.decodedToken);
     delete responsePayload.presentation_submission;
-    let siop = await (await responder.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
-    result = await validator!.validate(siop);
-    expect(result.result).toBeFalsy('Remove presentation_submission');
-    expect(result.detailedError).toEqual(`Verifiable credential 'IdentityCard' is missing from the input request`);
-    expect(result.code).toEqual('VCSDKVTOR04');
+    let siop = await (await responderHelper.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
+    response = await validator!.validate(siop);
+    expect(response.result).toBeFalsy('Remove presentation_submission');
+    expect(response.detailedError).toEqual(`Verifiable credential 'IdentityCard' is missing from the input request`);
+    expect(response.code).toEqual('VCSDKVTOR04');
     
     //Remove tokens
-    responsePayload = clone(response.decodedToken);
+    responsePayload = clone(responderResponse.decodedToken);
     delete responsePayload.presentation_submission.attestations;
-    siop = await (await responder.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
-    result = await validator!.validate(siop);
-    expect(result.result).toBeFalsy('Remove tokens');
-    expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
-    expect(result.code).toEqual('VCSDKCLTO03');
+    siop = await (await responderHelper.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
+    response = await validator!.validate(siop);
+    expect(response.result).toBeFalsy('Remove tokens');
+    expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
+    expect(response.code).toEqual('VCSDKCLTO03');
 
     //Remove path
-    responsePayload = clone(response.decodedToken);
+    responsePayload = clone(responderResponse.decodedToken);
     delete responsePayload.presentation_submission.descriptor_map[0].path;
-    siop = await (await responder.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
-    result = await validator!.validate(siop);
-    expect(result.result).toBeFalsy('Remove path');
-    expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);
-    expect(result.code).toEqual('VCSDKCLTO05');
+    siop = await (await responderHelper.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
+    response = await validator!.validate(siop);
+    expect(response.result).toBeFalsy('Remove path');
+    expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);
+    expect(response.code).toEqual('VCSDKCLTO05');
   });
 
   it('should create a response and validate - json ld', async () => {
     let model = new RequestOneJsonLdVcResponseOk();
     let requestor = new RequestorHelper(model);
     await requestor.setup();
-    let responder = new ResponderHelper(requestor, model);
-    await responder.setup('EdDSA');
+    let responderHelper = new ResponderHelper(requestor, model);
+    await responderHelper.setup('EdDSA');
 
     // add did
-    model.response.presentation_submission.attestations.presentations.IdentityCard.credentialSubject.id = responder.crypto.builder.did;
+    model.response.presentation_submission.attestations.presentations.IdentityCard.credentialSubject.id = responderHelper.crypto.builder.did;
 
     const request: any = await requestor.createPresentationExchangeRequest();
     expect(request.rawToken).toBeDefined();
     console.log(request.rawToken);
 
-    let response = await responder.createResponse(JoseBuilder.JSONLDProofs);
+    let responderResponse = await responderHelper.createResponse(JoseBuilder.JSONLDProofs);
 
     let validator = new ValidatorBuilder(requestor.crypto)
-      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
+      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responderHelper.generator.crypto.builder.did!] })
       .build();
-    let result = await validator.validate(<string>response.rawToken);
-    expect(result.result).toBeTruthy(result.detailedError);
+    let response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.result).toBeTruthy(response.detailedError);
 
     // Negative cases
 
@@ -117,86 +117,86 @@ describe('PresentationExchange', () => {
     validator = new ValidatorBuilder(requestor.crypto)
       .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [] })
       .build();
-    result = await validator.validate(<string>response.rawToken);
-    expect(result.detailedError).toEqual(`The verifiable credential with type 'IdentityCard' is not from a trusted issuer '{"IdentityCard":[]}'`);
-    expect(result.code).toEqual('VCSDKVCVA12');
+    response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.detailedError).toEqual(`The verifiable credential with type 'IdentityCard' is not from a trusted issuer '{"IdentityCard":[]}'`);
+    expect(response.code).toEqual('VCSDKVCVA12');
 
     validator = new ValidatorBuilder(requestor.crypto)
       .useTrustedIssuersForVerifiableCredentials({ IdentityCard: ['some did'] })
       .build();
-    result = await validator.validate(<string>response.rawToken);
-    expect(result.detailedError).toEqual(`The verifiable credential with type 'IdentityCard' is not from a trusted issuer '{"IdentityCard":["some did"]}'`);
-    expect(result.code).toEqual('VCSDKVCVA12');
+    response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.detailedError).toEqual(`The verifiable credential with type 'IdentityCard' is not from a trusted issuer '{"IdentityCard":["some did"]}'`);
+    expect(response.code).toEqual('VCSDKVCVA12');
 
     // wrong siop in vc
     model = new RequestOneJsonLdVcResponseWrongSiopDId();
-    responder = new ResponderHelper(requestor, model);
-    await responder.setup('EdDSA');
+    responderHelper = new ResponderHelper(requestor, model);
+    await responderHelper.setup('EdDSA');
     
-    response = await responder.createResponse(JoseBuilder.JSONLDProofs);
+    responderResponse = await responderHelper.createResponse(JoseBuilder.JSONLDProofs);
 
     validator = new ValidatorBuilder(requestor.crypto)
-      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
+      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responderHelper.generator.crypto.builder.did!] })
       .build();
-    result = await validator.validate(<string>response.rawToken);
-    expect(result.detailedError).toEqual(`The verifiable credential with type 'IdentityCard', the id in the credentialSubject property does not match the presenter DID: did:test:responder`);
-    expect(result.code).toEqual('VCSDKVCVA11');
+    response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.detailedError).toEqual(`The verifiable credential with type 'IdentityCard', the id in the credentialSubject property does not match the presenter DID: did:test:responder`);
+    expect(response.code).toEqual('VCSDKVCVA11');
   });
 
   it('should fail because of missing proof in vc - json ld', async () => {
     let model = new RequestOneJsonLdVcResponseNoProofInVC();
     let requestor = new RequestorHelper(model);
     await requestor.setup();
-    let responder = new ResponderHelper(requestor, model);
-    await responder.setup('EdDSA');
+    let responderHelper = new ResponderHelper(requestor, model);
+    await responderHelper.setup('EdDSA');
 
     // add did
-    model.response.presentation_submission.attestations.presentations.IdentityCard.credentialSubject.id = responder.crypto.builder.did;
-    let response = await responder.createResponse(JoseBuilder.JSONLDProofs);
+    model.response.presentation_submission.attestations.presentations.IdentityCard.credentialSubject.id = responderHelper.crypto.builder.did;
+    let responderResponse = await responderHelper.createResponse(JoseBuilder.JSONLDProofs);
 
     let validator = new ValidatorBuilder(requestor.crypto)
-      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
+      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responderHelper.generator.crypto.builder.did!] })
       .build();
-    let result = await validator.validate(<string>response.rawToken);
-    expect(result.detailedError).toEqual('The proof is not available in the json ld payload');
-    expect(result.code).toEqual('VCSDKVAHE06');
+    let response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.detailedError).toEqual('The proof is not available in the json ld payload');
+    expect(response.code).toEqual('VCSDKVAHE06');
 
     // missing verificationMethod
     model = new RequestOneJsonLdVcResponseNoProofInVC();
-    responder = new ResponderHelper(requestor, model);
-    await responder.setup('EdDSA');
+    responderHelper = new ResponderHelper(requestor, model);
+    await responderHelper.setup('EdDSA');
     model.responseOperations[0].path += '.verificationMethod';
-    response = await responder.createResponse(JoseBuilder.JSONLDProofs);
+    responderResponse = await responderHelper.createResponse(JoseBuilder.JSONLDProofs);
 
     validator = new ValidatorBuilder(requestor.crypto)
-      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
+      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responderHelper.generator.crypto.builder.did!] })
       .build();
-    result = await validator.validate(<string>response.rawToken);
-    expect(result.detailedError).toEqual('The proof does not contain the verificationMethod in the json ld payload');
-    expect(result.code).toEqual('VCSDKVAHE07');
+    response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.detailedError).toEqual('The proof does not contain the verificationMethod in the json ld payload');
+    expect(response.code).toEqual('VCSDKVAHE07');
   });
 
   it('should create a response and validate with VC with two credentialSubject - json ld', async () => {
     const model = new RequestOneJsonLdVcTwoSubjectsResponseOk();
     const requestor = new RequestorHelper(model);
     await requestor.setup();
-    const responder = new ResponderHelper(requestor, model);
-    await responder.setup('EdDSA');
+    const responderHelper = new ResponderHelper(requestor, model);
+    await responderHelper.setup('EdDSA');
 
     // add did
-    model.response.presentation_submission.attestations.presentations.IdentityCard.credentialSubject[0].id = responder.crypto.builder.did;
+    model.response.presentation_submission.attestations.presentations.IdentityCard.credentialSubject[0].id = responderHelper.crypto.builder.did;
 
     const request: any = await requestor.createPresentationExchangeRequest();
     expect(request.rawToken).toBeDefined();
     console.log(request.rawToken);
 
-    let response = await responder.createResponse(JoseBuilder.JSONLDProofs);
+    let responderResponse = await responderHelper.createResponse(JoseBuilder.JSONLDProofs);
 
     let validator = new ValidatorBuilder(requestor.crypto)
-      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
+      .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responderHelper.generator.crypto.builder.did!] })
       .build();
-    let result = await validator.validate(<string>response.rawToken);
-    expect(result.result).toBeTruthy(result.detailedError);
+    let response = await validator.validate(<string>responderResponse.rawToken);
+    expect(response.result).toBeTruthy(response.detailedError);
   });
 
   it('should populate the model', () => {

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -61,14 +61,22 @@ describe('PresentationExchange', () => {
 
     // Negative cases
 
-    //Remove presentation_submission
+    //Empy presentation_submission
     let responsePayload = clone(responderResponse.decodedToken);
-    delete responsePayload.presentation_submission;
+    responsePayload.presentation_submission = {};
     let siop = await (await responderHelper.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
     response = await validator!.validate(siop);
-    expect(response.result).toBeFalsy('Remove presentation_submission');
+    expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual(`Verifiable credential 'IdentityCard' is missing from the input request`);
     expect(response.code).toEqual('VCSDKVTOR04');
+    
+    //Remove presentation_submission
+    delete responsePayload.presentation_submission;
+    siop = await (await responderHelper.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
+    response = await validator!.validate(siop);
+    expect(response.result).toBeFalsy(response.detailedError);
+    expect(response.detailedError).toEqual(`Not a valid SIOP`);
+    expect(response.code).toEqual('VCSDKSTVA05');
     
     //Remove tokens
     responsePayload = clone(responderResponse.decodedToken);
@@ -77,7 +85,7 @@ describe('PresentationExchange', () => {
     response = await validator!.validate(siop);
     expect(response.result).toBeFalsy('Remove tokens');
     expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
-    expect(response.code).toEqual('VCSDKCLTO03');
+    expect(response.code).toEqual('VCSDKSTVA04');
 
     //Remove path
     responsePayload = clone(responderResponse.decodedToken);
@@ -86,7 +94,7 @@ describe('PresentationExchange', () => {
     response = await validator!.validate(siop);
     expect(response.result).toBeFalsy('Remove path');
     expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);
-    expect(response.code).toEqual('VCSDKCLTO05');
+    expect(response.code).toEqual('VCSDKSTVA04');
   });
 
   it('should create a response and validate - json ld', async () => {

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -76,7 +76,7 @@ describe('PresentationExchange', () => {
     result = await validator!.validate(siop);
     expect(result.result).toBeFalsy('Remove tokens');
     expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
-    expect(result.code).toEqual('CLTO03');
+    expect(result.code).toEqual('VCSDKCLTO03');
 
     //Remove path
     responsePayload = clone(response.decodedToken);
@@ -85,7 +85,7 @@ describe('PresentationExchange', () => {
     result = await validator!.validate(siop);
     expect(result.result).toBeFalsy('Remove path');
     expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);
-    expect(result.code).toEqual('CLTO05');
+    expect(result.code).toEqual('VCSDKCLTO05');
   });
 
   it('should create a response and validate - json ld', async () => {

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -68,7 +68,8 @@ describe('PresentationExchange', () => {
     result = await validator!.validate(siop);
     expect(result.result).toBeFalsy('Remove presentation_submission');
     expect(result.detailedError).toEqual(`Verifiable credential 'IdentityCard' is missing from the input request`);
-
+    expect(result.code).toEqual('VCSDKVTOR04');
+    
     //Remove tokens
     responsePayload = clone(response.decodedToken);
     delete responsePayload.presentation_submission.attestations;
@@ -118,13 +119,15 @@ describe('PresentationExchange', () => {
       .build();
     result = await validator.validate(<string>response.rawToken);
     expect(result.detailedError).toEqual(`The verifiable credential with type 'IdentityCard' is not from a trusted issuer '{"IdentityCard":[]}'`);
+    expect(result.code).toEqual('VCSDKVCVA12');
 
     validator = new ValidatorBuilder(requestor.crypto)
       .useTrustedIssuersForVerifiableCredentials({ IdentityCard: ['some did'] })
       .build();
     result = await validator.validate(<string>response.rawToken);
     expect(result.detailedError).toEqual(`The verifiable credential with type 'IdentityCard' is not from a trusted issuer '{"IdentityCard":["some did"]}'`);
-    
+    expect(result.code).toEqual('VCSDKVCVA12');
+
     // wrong siop in vc
     model = new RequestOneJsonLdVcResponseWrongSiopDId();
     responder = new ResponderHelper(requestor, model);
@@ -137,6 +140,7 @@ describe('PresentationExchange', () => {
       .build();
     result = await validator.validate(<string>response.rawToken);
     expect(result.detailedError).toEqual(`The verifiable credential with type 'IdentityCard', the id in the credentialSubject property does not match the presenter DID: did:test:responder`);
+    expect(result.code).toEqual('VCSDKVCVA11');
   });
 
   it('should fail because of missing proof in vc - json ld', async () => {
@@ -155,6 +159,7 @@ describe('PresentationExchange', () => {
       .build();
     let result = await validator.validate(<string>response.rawToken);
     expect(result.detailedError).toEqual('The proof is not available in the json ld payload');
+    expect(result.code).toEqual('VCSDKVAHE06');
 
     // missing verificationMethod
     model = new RequestOneJsonLdVcResponseNoProofInVC();
@@ -168,6 +173,7 @@ describe('PresentationExchange', () => {
       .build();
     result = await validator.validate(<string>response.rawToken);
     expect(result.detailedError).toEqual('The proof does not contain the verificationMethod in the json ld payload');
+    expect(result.code).toEqual('VCSDKVAHE07');
   });
 
   it('should create a response and validate with VC with two credentialSubject - json ld', async () => {

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -68,7 +68,7 @@ describe('PresentationExchange', () => {
     response = await validator!.validate(siop);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual(`Verifiable credential 'IdentityCard' is missing from the input request`);
-    expect(response.code).toEqual('VCSDKVTOR04');
+    expect(response.code).toEqual('VCSDKVtor04');
     
     //Remove presentation_submission
     delete responsePayload.presentation_submission;
@@ -76,7 +76,7 @@ describe('PresentationExchange', () => {
     response = await validator!.validate(siop);
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual(`Not a valid SIOP`);
-    expect(response.code).toEqual('VCSDKSTVA05');
+    expect(response.code).toEqual('VCSDKSTVa05');
     
     //Remove tokens
     responsePayload = clone(responderResponse.decodedToken);
@@ -85,7 +85,7 @@ describe('PresentationExchange', () => {
     response = await validator!.validate(siop);
     expect(response.result).toBeFalsy('Remove tokens');
     expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
-    expect(response.code).toEqual('VCSDKSTVA04');
+    expect(response.code).toEqual('VCSDKSTVa04');
 
     //Remove path
     responsePayload = clone(responderResponse.decodedToken);
@@ -94,7 +94,7 @@ describe('PresentationExchange', () => {
     response = await validator!.validate(siop);
     expect(response.result).toBeFalsy('Remove path');
     expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);
-    expect(response.code).toEqual('VCSDKSTVA04');
+    expect(response.code).toEqual('VCSDKSTVa04');
   });
 
   it('should create a response and validate - json ld', async () => {
@@ -167,13 +167,13 @@ describe('PresentationExchange', () => {
       .build();
     let response = await validator.validate(<string>responderResponse.rawToken);
     expect(response.detailedError).toEqual('The proof is not available in the json ld payload');
-    expect(response.code).toEqual('VCSDKVAHE06');
+    expect(response.code).toEqual('VCSDKVaHe06');
 
     // missing verificationMethod
     model = new RequestOneJsonLdVcResponseNoProofInVC();
     responderHelper = new ResponderHelper(requestor, model);
     await responderHelper.setup('EdDSA');
-    model.responseOperations[0].path += '.verificationMethod';
+    model.preSiopResponseOperations[0].path += '.verificationMethod';
     responderResponse = await responderHelper.createResponse(JoseBuilder.JSONLDProofs);
 
     validator = new ValidatorBuilder(requestor.crypto)
@@ -181,7 +181,7 @@ describe('PresentationExchange', () => {
       .build();
     response = await validator.validate(<string>responderResponse.rawToken);
     expect(response.detailedError).toEqual('The proof does not contain the verificationMethod in the json ld payload');
-    expect(response.code).toEqual('VCSDKVAHE07');
+    expect(response.code).toEqual('VCSDKVaHe07');
   });
 
   it('should create a response and validate with VC with two credentialSubject - json ld', async () => {

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -76,6 +76,7 @@ describe('PresentationExchange', () => {
     result = await validator!.validate(siop);
     expect(result.result).toBeFalsy('Remove tokens');
     expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.IdentityCard' did not return a token.`);
+    expect(result.code).toEqual('CLTO03');
 
     //Remove path
     responsePayload = clone(response.decodedToken);
@@ -84,6 +85,7 @@ describe('PresentationExchange', () => {
     result = await validator!.validate(siop);
     expect(result.result).toBeFalsy('Remove path');
     expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. No path property found.`);
+    expect(result.code).toEqual('CLTO05');
   });
 
   it('should create a response and validate - json ld', async () => {

--- a/tests/Requestor.spec.ts
+++ b/tests/Requestor.spec.ts
@@ -26,7 +26,7 @@ describe('Requestor', () =>{
     const requestor = new RequestorBuilder(PresentationDefinition.presentationExchangeDefinition)
       .build();
 
-      expect(() => requestor.trustedIssuerConfigurationsForIdTokens()).toThrowError('Id Tokens only supported in Attestation Requestor model.');
-      expect(() => requestor.trustedIssuersForVerifiableCredentials()).toThrowError('trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.');
+      expect(() => requestor.trustedIssuerConfigurationsForIdTokens()).toThrowMatching((exception) => exception.message === `Id Tokens only supported in Attestation Requestor model.` && exception.code === 'VCSDKREQU01');
+      expect(() => requestor.trustedIssuersForVerifiableCredentials()).toThrowMatching((exception) => exception.message === `trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.` && exception.code === 'VCSDKREQU02');
     })
 });

--- a/tests/Requestor.spec.ts
+++ b/tests/Requestor.spec.ts
@@ -26,7 +26,7 @@ describe('Requestor', () =>{
     const requestor = new RequestorBuilder(PresentationDefinition.presentationExchangeDefinition)
       .build();
 
-      expect(() => requestor.trustedIssuerConfigurationsForIdTokens()).toThrowMatching((exception) => exception.message === `Id Tokens only supported in Attestation Requestor model.` && exception.code === 'VCSDKREQU01');
-      expect(() => requestor.trustedIssuersForVerifiableCredentials()).toThrowMatching((exception) => exception.message === `trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.` && exception.code === 'VCSDKREQU02');
+      expect(() => requestor.trustedIssuerConfigurationsForIdTokens()).toThrowMatching((exception) => exception.message === `Id Tokens only supported in Attestation Requestor model.` && exception.code === 'VCSDKRequ01');
+      expect(() => requestor.trustedIssuersForVerifiableCredentials()).toThrowMatching((exception) => exception.message === `trustedIssuersForVerifiableCredentials not supported for presentation exchange. Requires constraints.` && exception.code === 'VCSDKRequ02');
     })
 });

--- a/tests/RequestorBuilder.spec.ts
+++ b/tests/RequestorBuilder.spec.ts
@@ -1,5 +1,5 @@
 import IRequestorAttestation from '../lib/api_oidc_request/IRequestorAttestation';
-import { LongFormDid, KeyReference, KeyUse, Crypto, IssuanceAttestationsModel, SelfIssuedAttestationModel, VerifiablePresentationAttestationModel, TrustedIssuerModel, InputClaimModel, IdTokenAttestationModel, CryptoBuilder, RequestorBuilder, IResponse, Requestor } from '../lib/index';
+import { LongFormDid, KeyReference, KeyUse, Crypto, IssuanceAttestationsModel, SelfIssuedAttestationModel, VerifiablePresentationAttestationModel, TrustedIssuerModel, InputClaimModel, IdTokenAttestationModel, CryptoBuilder, RequestorBuilder, IResponse, Requestor, ValidatorBuilder } from '../lib/index';
 
 describe('RequestorBuilder', () => {
   const getAttestations = () => {
@@ -98,6 +98,12 @@ describe('RequestorBuilder', () => {
     builder.useOidcRequestExpiry(60 * 60);
     expect(builder.OidcRequestExpiry).toEqual(60 * 60);
 
+    // Set requestor in validator
+    const requestor = builder.build();
+    const validator = new ValidatorBuilder(crypto)
+      .useRequestor(requestor)
+      .build();
+    expect(validator.builder.requestor).toEqual(requestor);
   });
 
   it('should sign the request', async () => {

--- a/tests/RuleProcessor.spec.ts
+++ b/tests/RuleProcessor.spec.ts
@@ -142,6 +142,7 @@ describe('Rule processor', () => {
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
       expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map without id property`);
+      expect(result.code).toEqual('CLTO02');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -202,7 +203,7 @@ describe('Rule processor', () => {
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
       expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.*' points to multiple credentails and should only point to one credential.`)
-
+      expect(result.code).toEqual('CLTO04');
     } finally {
       TokenGenerator.fetchMock.reset();
     }

--- a/tests/RuleProcessor.spec.ts
+++ b/tests/RuleProcessor.spec.ts
@@ -142,7 +142,7 @@ describe('Rule processor', () => {
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
       expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map without id property`);
-      expect(result.code).toEqual('CLTO02');
+      expect(result.code).toEqual('VCSDKCLTO02');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -203,7 +203,7 @@ describe('Rule processor', () => {
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
       expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.*' points to multiple credentails and should only point to one credential.`)
-      expect(result.code).toEqual('CLTO04');
+      expect(result.code).toEqual('VCSDKCLTO04');
     } finally {
       TokenGenerator.fetchMock.reset();
     }

--- a/tests/RuleProcessor.spec.ts
+++ b/tests/RuleProcessor.spec.ts
@@ -33,23 +33,23 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeTruthy();
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeTruthy();
 
-      expect(result.validationResult!.verifiableCredentials!['IdentityCard'].decodedToken.jti).toEqual(model.getVcFromResponse('IdentityCard').decodedToken.jti);
-      const jti = result.validationResult!.verifiablePresentations!['IdentityCard'].decodedToken.jti;
-      expect(result.validationResult!.verifiablePresentationStatus![jti].status).toEqual('valid');
+      expect(response.validationResult!.verifiableCredentials!['IdentityCard'].decodedToken.jti).toEqual(model.getVcFromResponse('IdentityCard').decodedToken.jti);
+      const jti = response.validationResult!.verifiablePresentations!['IdentityCard'].decodedToken.jti;
+      expect(response.validationResult!.verifiablePresentationStatus![jti].status).toEqual('valid');
 
-      const vc = result.validationResult!.verifiableCredentials!['IdentityCard'];
-      result = await validator.validate(<string>vc.rawToken);
-      expect(result.result).toBeTruthy();
+      const vc = response.validationResult!.verifiableCredentials!['IdentityCard'];
+      response = await validator.validate(<string>vc.rawToken);
+      expect(response.result).toBeTruthy();
 
     } finally {
       TokenGenerator.fetchMock.reset();
@@ -67,8 +67,8 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
@@ -78,8 +78,8 @@ describe('Rule processor', () => {
       // Status mock
       TokenGenerator.fetchMock.post('https://status.example.com', {status: 400, body: {}}, { overwriteRoutes: true });
 
-      let result = await validator.validate(response);
-      expect(result.result).toBeFalsy(result.detailedError);
+      let response = await validator.validate(responderResponse);
+      expect(response.result).toBeFalsy(response.detailedError);
 
     } finally {
       TokenGenerator.fetchMock.reset();
@@ -102,19 +102,19 @@ describe('Rule processor', () => {
       // add did
       model.response.presentation_submission.attestations.presentations.IdentityCard.credentialSubject.id = responder.crypto.builder.did;
 
-      const response = await responder.createResponse(JoseBuilder.JSONLDProofs);
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse(JoseBuilder.JSONLDProofs);
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!] })
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeTruthy();
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeTruthy();
 
-      expect(result.validationResult!.verifiableCredentials!['IdentityCard'].decodedToken.id).toEqual(model.getVcFromResponse('IdentityCard').decodedToken.id);
-      //const jti = result.validationResult!.verifiablePresentations!['IdentityCard'].decodedToken.id;
-      //expect(result.validationResult!.verifiablePresentationStatus![jti].status).toEqual('valid');
+      expect(response.validationResult!.verifiableCredentials!['IdentityCard'].decodedToken.id).toEqual(model.getVcFromResponse('IdentityCard').decodedToken.id);
+      //const jti = response.validationResult!.verifiablePresentations!['IdentityCard'].decodedToken.id;
+      //expect(response.validationResult!.verifiablePresentationStatus![jti].status).toEqual('valid');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -132,17 +132,17 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!], Diploma: [responder.generator.crypto.builder.did!] })
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeFalsy();
-      expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map without id property`);
-      expect(result.code).toEqual('VCSDKCLTO02');
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeFalsy();
+      expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map without id property`);
+      expect(response.code).toEqual('VCSDKCLTO02');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -160,22 +160,22 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!], Diploma: [responder.generator.crypto.builder.did!] })
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeTruthy();
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeTruthy();
 
-      expect(result.validationResult!.verifiableCredentials!['IdentityCard'].decodedToken.jti).toEqual(model.getVcFromResponse('IdentityCard').decodedToken.jti);
-      const jtiIdentity = result.validationResult!.verifiablePresentations!['IdentityCard'].decodedToken.jti;
-      const jtiDiploma = result.validationResult!.verifiablePresentations!['Diploma'].decodedToken.jti;
+      expect(response.validationResult!.verifiableCredentials!['IdentityCard'].decodedToken.jti).toEqual(model.getVcFromResponse('IdentityCard').decodedToken.jti);
+      const jtiIdentity = response.validationResult!.verifiablePresentations!['IdentityCard'].decodedToken.jti;
+      const jtiDiploma = response.validationResult!.verifiablePresentations!['Diploma'].decodedToken.jti;
       expect(jtiDiploma === jtiIdentity).toBeFalsy();
-      expect(result.validationResult!.verifiablePresentationStatus![jtiIdentity].status).toEqual('valid');
-      expect(result.validationResult!.verifiablePresentationStatus![jtiDiploma].status).toEqual('valid');
+      expect(response.validationResult!.verifiablePresentationStatus![jtiIdentity].status).toEqual('valid');
+      expect(response.validationResult!.verifiablePresentationStatus![jtiDiploma].status).toEqual('valid');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -193,17 +193,17 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!], Diploma: [responder.generator.crypto.builder.did!] })
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeFalsy();
-      expect(result.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.*' points to multiple credentails and should only point to one credential.`)
-      expect(result.code).toEqual('VCSDKCLTO04');
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeFalsy();
+      expect(response.detailedError).toEqual(`The SIOP presentation exchange response has descriptor_map with id 'IdentityCard'. This path '$.presentation_submission.attestations.presentations.*' points to multiple credentails and should only point to one credential.`)
+      expect(response.code).toEqual('VCSDKCLTO04');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -221,16 +221,16 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!], Diploma: [responder.generator.crypto.builder.did!] }).enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeFalsy();
-      expect(result.detailedError).toEqual(`Verifiable credential 'Diploma' is missing from the input request`);
-      expect(result.code).toEqual('VCSDKVTOR04');
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeFalsy();
+      expect(response.detailedError).toEqual(`Verifiable credential 'Diploma' is missing from the input request`);
+      expect(response.code).toEqual('VCSDKVTOR04');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -248,16 +248,16 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ IdentityCard: [responder.generator.crypto.builder.did!], Diploma: [responder.generator.crypto.builder.did!] }).enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeFalsy();
-      expect(result.detailedError?.startsWith('The status receipt for jti ') && result.detailedError?.endsWith(' failed with status revoked.')).toBeTruthy();
-      expect(result.code).toEqual('VCSDKVTOR07');
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeFalsy();
+      expect(response.detailedError?.startsWith('The status receipt for jti ') && response.detailedError?.endsWith(' failed with status revoked.')).toBeTruthy();
+      expect(response.code).toEqual('VCSDKVTOR07');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -275,33 +275,33 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       let validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ InsuranceCredential: [responder.generator.crypto.builder.did!], DriversLicenseCredential: [responder.generator.crypto.builder.did!] })
         .useTrustedIssuerConfigurationsForIdTokens(['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'])
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeTruthy();
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeTruthy();
 
-      expect(result.validationResult!.verifiableCredentials!['InsuranceCredential'].decodedToken.jti).toEqual(model.getVcFromResponse('InsuranceCredential').decodedToken.jti);
-      const jtiInsurance = result.validationResult!.verifiablePresentations!['InsuranceCredential'].decodedToken.jti;
-      const jtiLicense = result.validationResult!.verifiablePresentations!['DriversLicenseCredential'].decodedToken.jti;
+      expect(response.validationResult!.verifiableCredentials!['InsuranceCredential'].decodedToken.jti).toEqual(model.getVcFromResponse('InsuranceCredential').decodedToken.jti);
+      const jtiInsurance = response.validationResult!.verifiablePresentations!['InsuranceCredential'].decodedToken.jti;
+      const jtiLicense = response.validationResult!.verifiablePresentations!['DriversLicenseCredential'].decodedToken.jti;
       expect(jtiLicense === jtiInsurance).toBeFalsy();
-      expect(result.validationResult!.verifiablePresentationStatus![jtiInsurance].status).toEqual('valid');
-      expect(result.validationResult!.verifiablePresentationStatus![jtiLicense].status).toEqual('valid');
-      expect(result.validationResult!.idTokens!['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'].decodedToken.firstName).toEqual('Jules');
-      expect(result.validationResult?.selfIssued!.decodedToken.name).toEqual('Jules Winnfield');
+      expect(response.validationResult!.verifiablePresentationStatus![jtiInsurance].status).toEqual('valid');
+      expect(response.validationResult!.verifiablePresentationStatus![jtiLicense].status).toEqual('valid');
+      expect(response.validationResult!.idTokens!['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'].decodedToken.firstName).toEqual('Jules');
+      expect(response.validationResult?.selfIssued!.decodedToken.name).toEqual('Jules Winnfield');
 
       // present id token
       validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuerConfigurationsForIdTokens(['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'])
         .build();
-      result = await validator.validate(<string>result.validationResult!.idTokens!['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'].rawToken);
-      expect(result.result).toBeTruthy();
-      expect(result.validationResult!.idTokens!['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'].decodedToken.firstName).toEqual('Jules');
+      response = await validator.validate(<string>response.validationResult!.idTokens!['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'].rawToken);
+      expect(response.result).toBeTruthy();
+      expect(response.validationResult!.idTokens!['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'].decodedToken.firstName).toEqual('Jules');
 
     } finally {
       TokenGenerator.fetchMock.reset();
@@ -320,18 +320,18 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ InsuranceCredential: [responder.generator.crypto.builder.did!], DriversLicenseCredential: [responder.generator.crypto.builder.did!] })
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .useTrustedIssuerConfigurationsForIdTokens(['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'])
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeFalsy();
-      expect(result.detailedError).toEqual(`Verifiable credential 'DriversLicenseCredential' is missing from the input request`);
-      expect(result.code).toEqual('VCSDKVTOR04');
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeFalsy();
+      expect(response.detailedError).toEqual(`Verifiable credential 'DriversLicenseCredential' is missing from the input request`);
+      expect(response.code).toEqual('VCSDKVTOR04');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -349,18 +349,18 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .useTrustedIssuersForVerifiableCredentials({ InsuranceCredential: [responder.generator.crypto.builder.did!], DriversLicenseCredential: [responder.generator.crypto.builder.did!] })
         .enableFeatureVerifiedCredentialsStatusCheck(true)
         .useTrustedIssuerConfigurationsForIdTokens(['https://pics-linux.azurewebsites.net/test/oidc/openid-configuration'])
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeFalsy();
-      expect(result.detailedError).toEqual(`The id token is missing from the input request`);
-      expect(result.code).toEqual('VCSDKVTOR05');
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeFalsy();
+      expect(response.detailedError).toEqual(`The id token is missing from the input request`);
+      expect(response.code).toEqual('VCSDKVTOR05');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -379,16 +379,16 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeTruthy();
-      expect(result.validationResult?.selfIssued!.decodedToken.name).toEqual('Jules Winnfield');
-      expect(result.validationResult?.idTokens).toBeUndefined();
-      expect(result.validationResult?.verifiableCredentials).toBeUndefined();
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeTruthy();
+      expect(response.validationResult?.selfIssued!.decodedToken.name).toEqual('Jules Winnfield');
+      expect(response.validationResult?.idTokens).toBeUndefined();
+      expect(response.validationResult?.verifiableCredentials).toBeUndefined();
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -407,16 +407,16 @@ describe('Rule processor', () => {
 
       const responder = new ResponderHelper(requestor, model);
       await responder.setup();
-      const response = await responder.createResponse();
-      console.log(`=====> Response: ${response.rawToken}`);
+      const responderResponse = await responder.createResponse();
+      console.log(`=====> Response: ${responderResponse.rawToken}`);
 
       const validator = new ValidatorBuilder(requestor.crypto)
         .build();
-      let result = await validator.validate(<string>response.rawToken);
-      expect(result.result).toBeTruthy();
-      expect(result.validationResult?.selfIssued!.decodedToken.name).toEqual('Jules Winnfield');
-      expect(result.validationResult?.idTokens).toBeUndefined();
-      expect(result.validationResult?.verifiableCredentials).toBeUndefined();
+      let response = await validator.validate(<string>responderResponse.rawToken);
+      expect(response.result).toBeTruthy();
+      expect(response.validationResult?.selfIssued!.decodedToken.name).toEqual('Jules Winnfield');
+      expect(response.validationResult?.idTokens).toBeUndefined();
+      expect(response.validationResult?.verifiableCredentials).toBeUndefined();
     } finally {
       TokenGenerator.fetchMock.reset();
     }

--- a/tests/RuleProcessor.spec.ts
+++ b/tests/RuleProcessor.spec.ts
@@ -229,7 +229,8 @@ describe('Rule processor', () => {
         .build();
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
-      expect(result.detailedError).toEqual(`Verifiable credential 'Diploma' is missing from the input request`)
+      expect(result.detailedError).toEqual(`Verifiable credential 'Diploma' is missing from the input request`);
+      expect(result.code).toEqual('VCSDKVTOR04');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -256,6 +257,7 @@ describe('Rule processor', () => {
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
       expect(result.detailedError?.startsWith('The status receipt for jti ') && result.detailedError?.endsWith(' failed with status revoked.')).toBeTruthy();
+      expect(result.code).toEqual('VCSDKVTOR07');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -329,6 +331,7 @@ describe('Rule processor', () => {
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
       expect(result.detailedError).toEqual(`Verifiable credential 'DriversLicenseCredential' is missing from the input request`);
+      expect(result.code).toEqual('VCSDKVTOR04');
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -357,6 +360,7 @@ describe('Rule processor', () => {
       let result = await validator.validate(<string>response.rawToken);
       expect(result.result).toBeFalsy();
       expect(result.detailedError).toEqual(`The id token is missing from the input request`);
+      expect(result.code).toEqual('VCSDKVTOR05');
     } finally {
       TokenGenerator.fetchMock.reset();
     }

--- a/tests/SiopTokenValidator.spec.ts
+++ b/tests/SiopTokenValidator.spec.ts
@@ -59,7 +59,7 @@ describe('SiopTokenValidator', () => {
     response = await validator.validate(queue, queue.getNextToken()!);
     expect(response.result).toBeFalsy();
     expect(response.detailedError).toEqual(`Expected state 'state' does not match 'xxx'.`);
-    expect(response.code).toEqual('VCSDKSTVA02');
+    expect(response.code).toEqual('VCSDKSTVa02');
 
     // wrong state in response
     payload = {
@@ -73,7 +73,7 @@ describe('SiopTokenValidator', () => {
     response = await validator.validate(queue, queue.getNextToken()!);
     expect(response.result).toBeFalsy();
     expect(response.detailedError).toEqual(`Expected nonce 'nonce' does not match 'xxx'.`);
-    expect(response.code).toEqual('VCSDKSTVA01');
+    expect(response.code).toEqual('VCSDKSTVa01');
   });
 
 });

--- a/tests/SiopTokenValidator.spec.ts
+++ b/tests/SiopTokenValidator.spec.ts
@@ -58,7 +58,8 @@ describe('SiopTokenValidator', () => {
     queue.enqueueToken('siop', siopRequest);
     response = await validator.validate(queue, queue.getNextToken()!);
     expect(response.result).toBeFalsy();
-    expect(response.detailedError).toEqual(`Expect state 'state' does not match 'xxx'.`);
+    expect(response.detailedError).toEqual(`Expected state 'state' does not match 'xxx'.`);
+    expect(response.code).toEqual('VCSDKSTVA02');
 
     // wrong state in response
     payload = {
@@ -71,8 +72,8 @@ describe('SiopTokenValidator', () => {
     queue.enqueueToken('siop', siopRequest);
     response = await validator.validate(queue, queue.getNextToken()!);
     expect(response.result).toBeFalsy();
-    expect(response.detailedError).toEqual(`Expect nonce 'nonce' does not match 'xxx'.`);
-
+    expect(response.detailedError).toEqual(`Expected nonce 'nonce' does not match 'xxx'.`);
+    expect(response.code).toEqual('VCSDKSTVA01');
   });
 
 });

--- a/tests/SiopValidation.spec.ts
+++ b/tests/SiopValidation.spec.ts
@@ -41,6 +41,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing iss property in siop. Expected 'https://self-issued.me'`);
+    expect(response.code).toEqual('VCSDKVAHE23');
 
     // Bad iss
     payload = {
@@ -51,6 +52,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong iss property in siop. Expected 'https://self-issued.me'`);
+    expect(response.code).toEqual('VCSDKVAHE24');
 
     // Missing aud
     payload = {
@@ -61,6 +63,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing aud property in siop`);
+    expect(response.code).toEqual('VCSDKVAHE25');
 
     // Wrong aud
     payload = {
@@ -72,6 +75,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong aud property in siop. Expected 'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/card/issue'`);
+    expect(response.code).toEqual('VCSDKVAHE26');
 
     // Bad validation
     const testValidator = new DidValidation(validationOptions, expected);

--- a/tests/SiopValidation.spec.ts
+++ b/tests/SiopValidation.spec.ts
@@ -41,7 +41,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing iss property in siop. Expected 'https://self-issued.me'`);
-    expect(response.code).toEqual('VCSDKVAHE23');
+    expect(response.code).toEqual('VCSDKVaHe23');
 
     // Bad iss
     payload = {
@@ -52,7 +52,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong iss property in siop. Expected 'https://self-issued.me'`);
-    expect(response.code).toEqual('VCSDKVAHE24');
+    expect(response.code).toEqual('VCSDKVaHe24');
 
     // Missing aud
     payload = {
@@ -63,7 +63,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing aud property in siop`);
-    expect(response.code).toEqual('VCSDKVAHE25');
+    expect(response.code).toEqual('VCSDKVaHe25');
 
     // Wrong aud
     payload = {
@@ -75,7 +75,7 @@ describe('SiopValidation', () =>
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong aud property in siop. Expected 'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/card/issue'`);
-    expect(response.code).toEqual('VCSDKVAHE26');
+    expect(response.code).toEqual('VCSDKVaHe26');
 
     // Bad validation
     const testValidator = new DidValidation(validationOptions, expected);

--- a/tests/TokenGenerator.ts
+++ b/tests/TokenGenerator.ts
@@ -163,7 +163,7 @@ export default class TokenGenerator {
     for (let inx = 0; inx < vc.length; inx++) {
       (vpTemplate.vp.verifiableCredential as string[]).push(<string>vc[inx].rawToken);
     }
-    const token = await (await this.responder.crypto.signingProtocol(JoseBuilder.JWT).sign(vpTemplate)).serialize();
+    const token = await (await this.responder.crypto.signingProtocol(JoseBuilder.JOSE).sign(vpTemplate)).serialize();
     return new ClaimToken(TokenType.verifiablePresentationJwt, token, '');
   }
 }

--- a/tests/ValidationHelpers.spec.ts
+++ b/tests/ValidationHelpers.spec.ts
@@ -102,6 +102,8 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The did 'did:test:user' does not have a public key with kid 'abcd'. Public key : 'undefined'`);
+    expect(response.code).toEqual('VCSDKVAHE01');
+    
     validationResponse.didKid = setup.defaulUserDidKid;
 
     // No did document
@@ -124,11 +126,14 @@ describe('ValidationHelpers', () => {
       status: 200,
       result: true
     };
-    validationResponse.did = 'did Jules';
+    validationResponse.did = 'didJules';
+    setup.fetchMock.get(`${setup.resolverUrl}/${validationResponse.did}`, { status: 404 }, { overwriteRoutes: true });
     const response = await options.resolveDidAndGetKeysDelegate(validationResponse);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
-    expect(response.detailedError).toEqual('Could not resolve DID \'did Jules\'');
+    expect(response.detailedError).toEqual(`Could not resolve DID 'didJules'`);
+    expect(response.code).toEqual('VCSDKMARE01');
+
   });
 
   it('should test validateDidSignatureDelegate', async () => {

--- a/tests/ValidationHelpers.spec.ts
+++ b/tests/ValidationHelpers.spec.ts
@@ -100,8 +100,8 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The kid is not referenced in the request');
-    validationResponse.didKid = setup.defaulUserDidKid;
     expect(response.code).toEqual('VCSDKVAHE10');
+    validationResponse.didKid = setup.defaulUserDidKid;
 
     // No public key
     validationResponse.didKid = 'abcd';
@@ -110,7 +110,6 @@ describe('ValidationHelpers', () => {
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The did 'did:test:user' does not have a public key with kid 'abcd'. Public key : 'undefined'`);
     expect(response.code).toEqual('VCSDKVAHE11');
-    
     validationResponse.didKid = setup.defaulUserDidKid;
 
     // No did document
@@ -123,8 +122,8 @@ describe('ValidationHelpers', () => {
     response = await options.resolveDidAndGetKeysDelegate(validationResponse);
     expect(response.result).toBeFalsy();
     expect(response.detailedError).toEqual(`Could not retrieve DID document 'did:test:user'`);
-    expect(response.status).toEqual(403);
     expect(response.code).toEqual('VCSDKVAHE08');
+    expect(response.status).toEqual(403);
 
   });
 
@@ -182,6 +181,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('Failed to validate signature');
+    expect(response.code).toEqual('VCSDKVAHE28');
 
     // no payload
     validationResponse = await options.getTokenObjectDelegate(validationResponse, `${splitToken[0]}..${splitToken[2]}`);
@@ -189,6 +189,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('Failed to validate signature');
+    expect(response.code).toEqual('VCSDKVAHE28');
   });
 
   it('should test checkTimeValidityOnTokenDelegate', () => {
@@ -213,15 +214,17 @@ describe('ValidationHelpers', () => {
 
     validationResponse.expiration = exp - 1000;
     response = options.checkTimeValidityOnTokenDelegate(validationResponse, 5);
-    expect(response.result).toBeFalsy('expired');
+    expect(response.result).toBeFalsy(response.result);
     expect(response.status).toEqual(403);
     expect(response.detailedError?.startsWith('The presented verifiableCredential is expired')).toBeTruthy();
+    expect(response.code).toEqual('VCSDKVAHE12');
 
     validationResponse.expiration = 0;
     response = options.checkTimeValidityOnTokenDelegate(validationResponse, 5);
-    expect(response.result).toBeFalsy('expired');
+    expect(response.result).toBeFalsy(response.result);
     expect(response.status).toEqual(403);
     expect(response.detailedError?.startsWith('The presented verifiableCredential is expired')).toBeTruthy();
+    expect(response.code).toEqual('VCSDKVAHE12');
 
     // Add nbf
     validationResponse.expiration = undefined;
@@ -232,9 +235,10 @@ describe('ValidationHelpers', () => {
     nbf = (new Date().getTime() / 1000) + 10;
     validationResponse.payloadObject = JSON.parse(`{"jti": "abcdefg", "nbf": ${nbf}}`);
     response = options.checkTimeValidityOnTokenDelegate(validationResponse, 5);
-    expect(response.result).toBeFalsy('not yet valid');
+    expect(response.result).toBeFalsy(response.result);
     expect(response.status).toEqual(403);
     expect(response.detailedError?.startsWith('The presented verifiableCredential is not yet valid')).toBeTruthy();
+    expect(response.code).toEqual('VCSDKVAHE40');
   });
 
   it('should test checkScopeValidityOnVcToken', () => {
@@ -305,6 +309,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(401);
     expect(response.detailedError).toEqual(`The audience undefined is invalid`);
+    expect(response.code).toEqual('VCSDKVAHE16');
     validationResponse.payloadObject.aud = audience;
 
     validationResponse.payloadObject.aud = 'xxx';

--- a/tests/ValidationHelpers.spec.ts
+++ b/tests/ValidationHelpers.spec.ts
@@ -38,7 +38,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(400);
     expect(response.detailedError).toEqual('The verifiableCredential could not be deserialized');
-    expect(response.code).toEqual('VCSDKVAHE01');
+    expect(response.code).toEqual('VCSDKVaHe01');
 
     // missing kid
     const header: any = JSON.parse(base64url.decode(splitToken[0]));
@@ -47,7 +47,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The protected header in the verifiableCredential does not contain the kid');
-    expect(response.code).toEqual('VCSDKVAHE05');
+    expect(response.code).toEqual('VCSDKVaHe05');
 
 
     // bad JWT deserialize 
@@ -56,20 +56,20 @@ describe('ValidationHelpers', () => {
     response = await options.getTokenObjectDelegate(validationResponse, '');
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('The payload in the verifiableCredential is undefined');
-    expect(response.code).toEqual('VCSDKVAHE03');
+    expect(response.code).toEqual('VCSDKVaHe03');
 
     protocol = options.validatorOptions.crypto.signingProtocol(JoseBuilder.JWT);
     deserializeSpy.and.callFake(() => <any>undefined);
     response = await options.getTokenObjectDelegate(validationResponse, '');
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('The signature in the verifiableCredential has an invalid format');
-    expect(response.code).toEqual('VCSDKVAHE02');
+    expect(response.code).toEqual('VCSDKVaHe02');
 
     deserializeSpy.and.callFake(() => { throw new Error('deserialize JWT error') });
     response = await options.getTokenObjectDelegate(validationResponse, '');
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('The verifiableCredential could not be deserialized');
-    expect(response.code).toEqual('VCSDKVAHE01');
+    expect(response.code).toEqual('VCSDKVaHe01');
 
     // bad json ld deserialize 
     protocol = options.validatorOptions.crypto.signingProtocol(JoseBuilder.JSONLDProofs);
@@ -77,7 +77,7 @@ describe('ValidationHelpers', () => {
     response = await options.getTokenObjectDelegate(validationResponse, {});
     expect(response.result).toBeFalsy(response.detailedError);
     expect(response.detailedError).toEqual('The verifiableCredential could not be deserialized');
-    expect(response.code).toEqual('VCSDKVAHE01');
+    expect(response.code).toEqual('VCSDKVaHe01');
     deserializeSpy.and.callFake(() => <any>{});
   });
 
@@ -100,7 +100,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The kid is not referenced in the request');
-    expect(response.code).toEqual('VCSDKVAHE10');
+    expect(response.code).toEqual('VCSDKVaHe10');
     validationResponse.didKid = setup.defaulUserDidKid;
 
     // No public key
@@ -109,7 +109,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The did 'did:test:user' does not have a public key with kid 'abcd'. Public key : 'undefined'`);
-    expect(response.code).toEqual('VCSDKVAHE11');
+    expect(response.code).toEqual('VCSDKVaHe11');
     validationResponse.didKid = setup.defaulUserDidKid;
 
     // No did document
@@ -122,7 +122,7 @@ describe('ValidationHelpers', () => {
     response = await options.resolveDidAndGetKeysDelegate(validationResponse);
     expect(response.result).toBeFalsy();
     expect(response.detailedError).toEqual(`Could not retrieve DID document 'did:test:user'`);
-    expect(response.code).toEqual('VCSDKVAHE08');
+    expect(response.code).toEqual('VCSDKVaHe08');
     expect(response.status).toEqual(403);
 
   });
@@ -139,7 +139,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Could not resolve DID 'didJules'`);
-    expect(response.code).toEqual('VCSDKVAHE09');
+    expect(response.code).toEqual('VCSDKVaHe09');
 
   });
 
@@ -164,7 +164,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiableCredential is invalid');
-    expect(response.code).toEqual('VCSDKVAHE27');
+    expect(response.code).toEqual('VCSDKVaHe27');
 
     // No signature
     const splitToken = (<string>request.rawToken).split('.');
@@ -173,7 +173,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiableCredential is invalid');
-    expect(response.code).toEqual('VCSDKVAHE27');
+    expect(response.code).toEqual('VCSDKVaHe27');
 
     // no header
     validationResponse = await options.getTokenObjectDelegate(validationResponse, `.${splitToken[1]}.${splitToken[2]}`);
@@ -181,7 +181,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('Failed to validate signature');
-    expect(response.code).toEqual('VCSDKVAHE28');
+    expect(response.code).toEqual('VCSDKVaHe28');
 
     // no payload
     validationResponse = await options.getTokenObjectDelegate(validationResponse, `${splitToken[0]}..${splitToken[2]}`);
@@ -189,7 +189,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('Failed to validate signature');
-    expect(response.code).toEqual('VCSDKVAHE28');
+    expect(response.code).toEqual('VCSDKVaHe28');
   });
 
   it('should test checkTimeValidityOnTokenDelegate', () => {
@@ -217,14 +217,14 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy(response.result);
     expect(response.status).toEqual(403);
     expect(response.detailedError?.startsWith('The presented verifiableCredential is expired')).toBeTruthy();
-    expect(response.code).toEqual('VCSDKVAHE12');
+    expect(response.code).toEqual('VCSDKVaHe12');
 
     validationResponse.expiration = 0;
     response = options.checkTimeValidityOnTokenDelegate(validationResponse, 5);
     expect(response.result).toBeFalsy(response.result);
     expect(response.status).toEqual(403);
     expect(response.detailedError?.startsWith('The presented verifiableCredential is expired')).toBeTruthy();
-    expect(response.code).toEqual('VCSDKVAHE12');
+    expect(response.code).toEqual('VCSDKVaHe12');
 
     // Add nbf
     validationResponse.expiration = undefined;
@@ -238,7 +238,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy(response.result);
     expect(response.status).toEqual(403);
     expect(response.detailedError?.startsWith('The presented verifiableCredential is not yet valid')).toBeTruthy();
-    expect(response.code).toEqual('VCSDKVAHE40');
+    expect(response.code).toEqual('VCSDKVaHe40');
   });
 
   it('should test checkScopeValidityOnVcToken', () => {
@@ -259,13 +259,13 @@ describe('ValidationHelpers', () => {
     // wrong did
     response = options.checkScopeValidityOnVcTokenDelegate(validationResponse, <any>{}, 'wrong did');
     expect(response.detailedError).toEqual(`Wrong sub property in verifiableCredential. Expected 'wrong did'`);
-    expect(response.code).toEqual('VCSDKVAHE22');
+    expect(response.code).toEqual('VCSDKVaHe22');
 
     // missing sub
     delete validationResponse.payloadObject.sub;
     response = options.checkScopeValidityOnVcTokenDelegate(validationResponse, <any>{}, 'did');
     expect(response.detailedError).toEqual(`Missing sub property in verifiableCredential. Expected 'did'`);
-    expect(response.code).toEqual('VCSDKVAHE21');
+    expect(response.code).toEqual('VCSDKVaHe21');
   });
 
   it('should test checkScopeValidityOnIdTokenDelegate', () => {
@@ -301,7 +301,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The issuer in configuration was not found`);
-    expect(response.code).toEqual('VCSDKVAHE13');
+    expect(response.code).toEqual('VCSDKVaHe13');
     validationResponse.expectedIssuer = issuer;
 
     validationResponse.payloadObject.aud = undefined;
@@ -309,7 +309,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(401);
     expect(response.detailedError).toEqual(`The audience undefined is invalid`);
-    expect(response.code).toEqual('VCSDKVAHE16');
+    expect(response.code).toEqual('VCSDKVaHe16');
     validationResponse.payloadObject.aud = audience;
 
     validationResponse.payloadObject.aud = 'xxx';
@@ -317,7 +317,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(401);
     expect(response.detailedError).toEqual(`The audience xxx is invalid`);
-    expect(response.code).toEqual('VCSDKVAHE16');
+    expect(response.code).toEqual('VCSDKVaHe16');
     validationResponse.payloadObject.aud = audience;
 
     validationResponse.issuer = 'xxx';
@@ -325,7 +325,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The issuer in configuration 'iss' does not correspond with the issuer in the payload xxx`);
-    expect(response.code).toEqual('VCSDKVAHE15');
+    expect(response.code).toEqual('VCSDKVaHe15');
     validationResponse.issuer = issuer;
 
     validationResponse.issuer = undefined;
@@ -333,7 +333,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing iss property in idToken. Expected '"iss"'`);
-    expect(response.code).toEqual('VCSDKVAHE14');
+    expect(response.code).toEqual('VCSDKVaHe14');
     validationResponse.issuer = issuer;
   });
 
@@ -379,7 +379,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('Could not fetch token configuration');
-    expect(response.code).toEqual('VCSDKVAHE34');
+    expect(response.code).toEqual('VCSDKVaHe34');
 
     // no keys in configuration
 
@@ -388,7 +388,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('No reference to jwks found in token configuration');
-    expect(response.code).toEqual('VCSDKVAHE30');
+    expect(response.code).toEqual('VCSDKVaHe30');
 
     // no issuer in configuration
     setup.fetchMock.get(setup.defaultIdTokenConfiguration, { "jwks_uri": `${setup.defaultIdTokenJwksConfiguration}` }, { overwriteRoutes: true });
@@ -396,7 +396,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('No issuer found in token configuration');
-    expect(response.code).toEqual('VCSDKVAHE33');
+    expect(response.code).toEqual('VCSDKVaHe33');
 
     // could not fetch keys
     [tokenJwkPrivate, tokenJwkPublic, tokenConfiguration] = await IssuanceHelpers.generateSigningKeyAndSetConfigurationMock(setup, setup.defaulIssuerDidKid);
@@ -405,7 +405,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Could not fetch keys needed to validate token on '${setup.defaultIdTokenJwksConfiguration}'`);
-    expect(response.code).toEqual('VCSDKVAHE31');
+    expect(response.code).toEqual('VCSDKVaHe31');
 
     // bad keys
     [tokenJwkPrivate, tokenJwkPublic, tokenConfiguration] = await IssuanceHelpers.generateSigningKeyAndSetConfigurationMock(setup, setup.defaulIssuerDidKid);
@@ -414,7 +414,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`No or bad jwks keys found in token configuration`);
-    expect(response.code).toEqual('VCSDKVAHE32');
+    expect(response.code).toEqual('VCSDKVaHe32');
     [tokenJwkPrivate, tokenJwkPublic, tokenConfiguration] = await IssuanceHelpers.generateSigningKeyAndSetConfigurationMock(setup, setup.defaulIssuerDidKid);
 
     setup.fetchMock.get(setup.defaultIdTokenJwksConfiguration, `test`, { overwriteRoutes: true });
@@ -422,7 +422,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Could not fetch token configuration`);
-    expect(response.code).toEqual('VCSDKVAHE34');
+    expect(response.code).toEqual('VCSDKVaHe34');
 
     // Failed signature
     [tokenJwkPrivate, tokenJwkPublic, tokenConfiguration] = await IssuanceHelpers.generateSigningKeyAndSetConfigurationMock(setup, setup.defaulIssuerDidKid);
@@ -451,7 +451,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Could not validate signature on id token`);
-    expect(response.code).toEqual('VCSDKVAHE36');
+    expect(response.code).toEqual('VCSDKVaHe36');
 
     // bad keys in configuration
     const badKey = {
@@ -471,7 +471,7 @@ describe('ValidationHelpers', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('Could not validate token signature');
-    expect(response.code).toEqual('VCSDKVAHE35');
+    expect(response.code).toEqual('VCSDKVaHe35');
   });
 
   it('should test fetchOpenIdTokenPublicKeysDelegate', async () => {
@@ -499,12 +499,12 @@ describe('ValidationHelpers', () => {
     setup.fetchMock.get(setup.defaultIdTokenJwksConfiguration, { "status": 400 }, { overwriteRoutes: true });
     response = <IValidationResponse>await options.fetchOpenIdTokenPublicKeysDelegate(validationResponse, idToken);
     expect(response.detailedError).toEqual(`Could not fetch keys needed to validate token on 'http://example/jwks'`);
-    expect(response.code).toEqual('VCSDKVAHE31');
+    expect(response.code).toEqual('VCSDKVaHe31');
 
     setup.fetchMock.get(setup.defaultIdTokenConfiguration, { "body": {} }, { overwriteRoutes: true });
     response = <IValidationResponse>await options.fetchOpenIdTokenPublicKeysDelegate(validationResponse, idToken);
     expect(response.detailedError).toEqual(`No reference to jwks found in token configuration`);
-    expect(response.code).toEqual('VCSDKVAHE30');
+    expect(response.code).toEqual('VCSDKVaHe30');
     /*
           setup.fetchMock.get(setup.defaultIdTokenConfiguration, {"body": {
             "jwks_uri": `setup.defaultIdTokenJwksConfiguration`
@@ -515,6 +515,7 @@ describe('ValidationHelpers', () => {
     setup.fetchMock.get(setup.defaultIdTokenConfiguration, { "status": 400 }, { overwriteRoutes: true });
     response = <IValidationResponse>await options.fetchOpenIdTokenPublicKeysDelegate(validationResponse, idToken);
     expect(response.detailedError).toEqual(`Could not fetch token configuration needed to validate token`);
-    expect(response.code).toEqual('VCSDKVAHE29');
+    expect(response.code).toEqual('VCSDKVaHe29');
+    expect(response.status).toEqual(403);
   });
 });

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -34,11 +34,11 @@ describe('Validator', () => {
     //expected.configuration = (<{ [contract: string]: string[]}>expected.configuration)[Validator.getContractIdFromSiop(siop.contract)];
 
     let tokenValidator = new IdTokenTokenValidator(setup.validatorOptions, expected);
-    expect(() => tokenValidator.getTokens(<any>undefined, <any>undefined)).toThrowError('Not implemented');
+    expect(() => tokenValidator.getTokens(<any>undefined, <any>undefined)).toThrowMatching((exception) => exception.message === `Not implemented` && exception.code === 'VCSDKIDTV01');
 
     let selfIssuedValidator = new SelfIssuedTokenValidator(setup.validatorOptions, expected);
     expect(selfIssuedValidator.isType).toEqual(TokenType.selfIssued);
-    expect(() => selfIssuedValidator.getTokens(<any>undefined, <any>undefined)).toThrowError('Not implemented');
+    expect(() => selfIssuedValidator.getTokens(<any>undefined, <any>undefined)).toThrowMatching((exception) => exception.message === `Not implemented` && exception.code === 'VCSDKSITV01');
 
     let validator = new ValidatorBuilder(crypto)
       .useValidators(tokenValidator)
@@ -85,7 +85,7 @@ describe('Validator', () => {
     const expected: any = siop.expected.filter((token: IExpectedVerifiableCredential) => token.type === TokenType.verifiableCredential)[0];
 
     const tokenValidator = new VerifiableCredentialTokenValidator(setup.validatorOptions, expected);
-    expect(() => tokenValidator.getTokens(<any>undefined, <any>undefined)).toThrowError('Not implemented');
+    expect(() => tokenValidator.getTokens(<any>undefined, <any>undefined)).toThrowMatching((exception) => exception.message === `Not implemented` && exception.code === 'VCSDKVCTV01');
 
     const validator = new ValidatorBuilder(crypto)
       .useValidators(tokenValidator)

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -169,7 +169,7 @@ describe('Validator', () => {
     expect(result.detailedError).toEqual('verifiableCredential does not has a TokenValidator');
   });
 
-  it('should validate presentation siop', async () => {    
+  it('should validate presentation siop', async () => {
     const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.verifiablePresentationJwt, false);
     const siopExpected = siop.expected.filter((token: IExpectedSiop) => token.type === TokenType.siopPresentationAttestation)[0];
     const vcExpected = siop.expected.filter((token: IExpectedVerifiableCredential) => token.type === TokenType.verifiableCredential)[0];

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -95,7 +95,14 @@ describe('Validator', () => {
     let response = await validator.validate(siop.vc.rawToken);
     expect(response.result).toBeTruthy();
 
-  });
+    // Negative cases
+    // VC signature failure
+    const splitted = siop.vc.rawToken.split('.');
+    response = await validator.validate(`${splitted[0]}.${splitted[1]}.1234${splitted[2]}`);
+    expect(response.result).toBeFalsy(response.detailedError);
+    expect(response.status).toEqual(403);
+    expect(response.code).toEqual('VCSDKVaHe27');
+});
 
   it('should validate verifiable presentations', async () => {
     const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.verifiablePresentationJwt, true);

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -357,33 +357,17 @@ describe('Validator', () => {
     expect(response).toEqual(id);
   });
 
-  xit('should validate a siop', async () => {
+  it('should validate a siop', async () => {
     setup.fetchMock.reset();
-    const credentials = new ClientSecretCredential(Credentials.tenantGuid, Credentials.clientId, Credentials.clientSecret);
-
-    const keyReference = new KeyReference('jsonldtest', 'secret'); const subtle = new Subtle();
-    const cryptoFactory = new CryptoFactoryNode(new KeyStoreKeyVault(credentials, Credentials.vaultUri, new KeyStoreInMemory()), subtle);
     let crypto = new CryptoBuilder()
-      .useSigningAlgorithm('EdDSA')
-      .useKeyVault(credentials, Credentials.vaultUri)
-      .useCryptoFactory(cryptoFactory)
-      .useSigningKeyReference(keyReference)
       .build();
 
-    crypto = await crypto.generateKey(KeyUse.Signature);
-    crypto = await crypto.generateKey(KeyUse.Signature, 'recovery');
-    crypto = await crypto.generateKey(KeyUse.Signature, 'update');
-    crypto.builder.useDid(await new LongFormDid(crypto).serialize());
-
     let validator = new ValidatorBuilder(crypto)
-      .useAudienceUrl('https://verify.vc.capptoso.com:443/presentation-response')
-      .useTrustedIssuersForVerifiableCredentials({ 'https://credentials.workday.com/docs/specification/v1.0/credential.json': ['did:work:CcZdQMaiwQyY2zA9njpx5p'] })
       .build();
 
     const req = 'your token here';
     console.log(req);
     const response = await validator.validate(req);
-    expect(response.result).toBeTruthy();
-    expect(response.status).toEqual(200);
+    expect(response.result).toBeFalsy();
   });
 });

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -45,24 +45,24 @@ describe('Validator', () => {
       .useTrustedIssuerConfigurationsForIdTokens([setup.defaultIdTokenConfiguration])
       .build();
 
-    let result = await validator.validate(siop.idToken.rawToken);
-    expect(result.result).toBeTruthy();
-    expect(result.validationResult?.idTokens).toBeDefined();
+    let response = await validator.validate(siop.idToken.rawToken);
+    expect(response.result).toBeTruthy();
+    expect(response.validationResult?.idTokens).toBeDefined();
 
     validator = new ValidatorBuilder(crypto)
       .useTrustedIssuerConfigurationsForIdTokens([setup.defaultIdTokenConfiguration])
       .build();
-    result = await validator.validate(siop.idToken.rawToken);
-    expect(result.result).toBeTruthy();
-    expect(result.validationResult?.idTokens).toBeDefined();
+    response = await validator.validate(siop.idToken.rawToken);
+    expect(response.result).toBeTruthy();
+    expect(response.validationResult?.idTokens).toBeDefined();
 
     //Redefine the urls
     validator = validator.builder.useTrustedIssuerConfigurationsForIdTokens([setup.defaultIdTokenConfiguration])
       .build();
-    result = await validator.validate(siop.idToken.rawToken);
-    expect(result.result).toBeTruthy();
+    response = await validator.validate(siop.idToken.rawToken);
+    expect(response.result).toBeTruthy();
     expect(validator.builder.trustedIssuerConfigurationsForIdTokens).toEqual([setup.defaultIdTokenConfiguration]);
-    expect(result.validationResult?.verifiablePresentations).toBeUndefined();
+    expect(response.validationResult?.verifiablePresentations).toBeUndefined();
 
     tokenValidator = new IdTokenTokenValidator(setup.validatorOptions, expected);
 
@@ -75,9 +75,10 @@ describe('Validator', () => {
       .useValidators(tokenValidator)
       .build();
 
-    result = await validator.validate(siop.idToken.rawToken);
-    expect(result.result).toBeFalsy();
-    expect(result.detailedError).toEqual(`Could not fetch token configuration`);
+    response = await validator.validate(siop.idToken.rawToken);
+    expect(response.result).toBeFalsy();
+    expect(response.detailedError).toEqual(`Could not fetch token configuration`);
+    expect(response.code).toEqual('VCSDKVAHE34');
   });
 
   it('should validate verifiable credentials', async () => {
@@ -91,8 +92,8 @@ describe('Validator', () => {
       .useValidators(tokenValidator)
       .build();
 
-    let result = await validator.validate(siop.vc.rawToken);
-    expect(result.result).toBeTruthy();
+    let response = await validator.validate(siop.vc.rawToken);
+    expect(response.result).toBeTruthy();
 
   });
 
@@ -122,30 +123,30 @@ describe('Validator', () => {
     // Check VP validator
     let queue = new ValidationQueue();
     queue.enqueueToken('vp', siop.vp);
-    let result = await vpValidator.validate(queue, queue.getNextToken()!, setup.defaultUserDid);
-    expect(result.result).toBeTruthy('vpValidator succeeded');
-    expect(result.tokensToValidate![`DrivingLicense`].rawToken).toEqual(siop.vc.rawToken);
+    let response = await vpValidator.validate(queue, queue.getNextToken()!, setup.defaultUserDid);
+    expect(response.result).toBeTruthy('vpValidator succeeded');
+    expect(response.tokensToValidate![`DrivingLicense`].rawToken).toEqual(siop.vc.rawToken);
 
-    let clonedResult = clone(result);
+    let clonedResult = clone(response);
     delete clonedResult.payloadObject.vp;
-    result = vpValidator.getTokens(clonedResult, queue);
-    expect(result.result).toBeFalsy(result.detailedError);
-    expect(result.detailedError).toEqual('No verifiable credential');
-    expect(result.code).toEqual('VCSDKVPTV01');
+    response = vpValidator.getTokens(clonedResult, queue);
+    expect(response.result).toBeFalsy(response.detailedError);
+    expect(response.detailedError).toEqual('No verifiable credential');
+    expect(response.code).toEqual('VCSDKVPTV01');
 
     // Check VC validator
     queue = new ValidationQueue();
     queue.enqueueToken(vcAttestationName, siop.vc);
-    result = await vcValidator.validate(queue, queue.getNextToken()!, setup.defaultUserDid);
-    expect(result.result).toBeTruthy('vcValidator succeeded');
+    response = await vcValidator.validate(queue, queue.getNextToken()!, setup.defaultUserDid);
+    expect(response.result).toBeTruthy('vcValidator succeeded');
 
     // Check validator
     queue = new ValidationQueue();
     queue.enqueueToken('vp', siop.vp);
     let token = queue.getNextToken()!.tokenToValidate;
-    result = await validator.validate(token);
-    expect(result.result).toBeTruthy('check validator');
-    expect(result.validationResult?.verifiableCredentials).toBeDefined();
+    response = await validator.validate(token);
+    expect(response.result).toBeTruthy('check validator');
+    expect(response.validationResult?.verifiableCredentials).toBeDefined();
 
     // Negative cases
     // No validator
@@ -154,10 +155,10 @@ describe('Validator', () => {
       .build();
     queue = new ValidationQueue();
     queue.enqueueToken('vp', siop.vp);
-    result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.result).toBeFalsy();
-    expect(result.detailedError).toEqual('verifiablePresentationJwt does not has a TokenValidator');
-    expect(result.code).toEqual('VCSDKVTOR02');
+    response = await validator.validate(queue.getNextToken()!.tokenToValidate);
+    expect(response.result).toBeFalsy();
+    expect(response.detailedError).toEqual('verifiablePresentationJwt does not has a TokenValidator');
+    expect(response.code).toEqual('VCSDKVTOR02');
 
     // Test validator with missing VC validator
     validator = new ValidatorBuilder(crypto)
@@ -166,10 +167,10 @@ describe('Validator', () => {
       .build();
     queue = new ValidationQueue();
     queue.enqueueToken('vp', siop.vp);
-    result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.result).toBeFalsy();
-    expect(result.detailedError).toEqual('verifiableCredential does not has a TokenValidator');
-    expect(result.code).toEqual('VCSDKVTOR02');
+    response = await validator.validate(queue.getNextToken()!.tokenToValidate);
+    expect(response.result).toBeFalsy();
+    expect(response.detailedError).toEqual('verifiableCredential does not has a TokenValidator');
+    expect(response.code).toEqual('VCSDKVTOR02');
   });
 
   it('should validate presentation siop', async () => {
@@ -189,44 +190,44 @@ describe('Validator', () => {
 
     const queue = new ValidationQueue();
     queue.enqueueToken('siopPresentationAttestation', request);
-    let result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.result).toBeTruthy();
-    expect(result.status).toEqual(200);
+    let response = await validator.validate(queue.getNextToken()!.tokenToValidate);
+    expect(response.result).toBeTruthy();
+    expect(response.status).toEqual(200);
     expect(validator.tokenValidators['siopPresentationAttestation'].isType).toEqual(TokenType.siopPresentationAttestation);
-    expect(result.validationResult?.siop).toBeDefined();
-    expect(result.validationResult?.verifiablePresentations).toBeDefined();
-    expect(result.detailedError).toBeUndefined();
-    expect(result.tokensToValidate).toBeUndefined();
-    expect(result.validationResult?.did).toEqual(setup.defaultUserDid);
-    expect(result.validationResult?.siopJti).toEqual(IssuanceHelpers.jti);
-    expect(result.validationResult?.idTokens).toBeUndefined();
-    expect(result.validationResult?.selfIssued).toBeUndefined();
-    expect(result.validationResult?.verifiableCredentials).toBeDefined();
-    expect(result.validationResult?.verifiableCredentials!['DrivingLicense'].decodedToken.vc.credentialSubject.givenName).toEqual('Jules');
+    expect(response.validationResult?.siop).toBeDefined();
+    expect(response.validationResult?.verifiablePresentations).toBeDefined();
+    expect(response.detailedError).toBeUndefined();
+    expect(response.tokensToValidate).toBeUndefined();
+    expect(response.validationResult?.did).toEqual(setup.defaultUserDid);
+    expect(response.validationResult?.siopJti).toEqual(IssuanceHelpers.jti);
+    expect(response.validationResult?.idTokens).toBeUndefined();
+    expect(response.validationResult?.selfIssued).toBeUndefined();
+    expect(response.validationResult?.verifiableCredentials).toBeDefined();
+    expect(response.validationResult?.verifiableCredentials!['DrivingLicense'].decodedToken.vc.credentialSubject.givenName).toEqual('Jules');
 
     // Negative cases
     // map issuer to other credential type
     validator = validator.builder.useTrustedIssuersForVerifiableCredentials({ someCredential: vcExpected.contractIssuers.DrivingLicense }).build();
     queue.enqueueToken('siopPresentationAttestation', request);
-    result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.result).toBeFalsy();
-    expect(result.detailedError).toEqual(`Expected should have contractIssuers set for verifiableCredential. Missing contractIssuers for 'DrivingLicense'.`);
-    expect(result.code).toEqual('VCSDKVCVA16');
-    expect(result.status).toEqual(403);
+    response = await validator.validate(queue.getNextToken()!.tokenToValidate);
+    expect(response.result).toBeFalsy();
+    expect(response.detailedError).toEqual(`Expected should have contractIssuers set for verifiableCredential. Missing contractIssuers for 'DrivingLicense'.`);
+    expect(response.code).toEqual('VCSDKVCVA16');
+    expect(response.status).toEqual(403);
 
     // bad payload
     queue.enqueueToken('siopPresentationAttestation', <any>{ claims: {} });
-    result = await validator.validate(<any>queue.getNextToken()!);
-    expect(result.detailedError).toEqual('Wrong token type. Expected string or ClaimToken');
-    expect(result.code).toEqual('VCSDKVTOR01');
+    response = await validator.validate(<any>queue.getNextToken()!);
+    expect(response.detailedError).toEqual('Wrong token type. Expected string or ClaimToken');
+    expect(response.code).toEqual('VCSDKVTOR01');
 
     let spiedMethod: any = ClaimToken.create;
     let createSpy: jasmine.Spy = spyOn(ClaimToken, 'create').and.callFake((): ClaimToken => {
       throw new Error('some create error');
     });
     queue.enqueueToken('siopPresentationAttestation', request);
-    result = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
-    expect(result.detailedError).toEqual('some create error');
+    response = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
+    expect(response.detailedError).toEqual('some create error');
     createSpy.and.callFake((token: any, id: any): { [key: string]: ClaimToken } => {
       return spiedMethod(token, id);
     });
@@ -236,8 +237,8 @@ describe('Validator', () => {
       throw new Error('some error');
     });
     queue.enqueueToken('siopPresentationAttestation', request);
-    result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.detailedError).toEqual('some error');
+    response = await validator.validate(queue.getNextToken()!.tokenToValidate);
+    expect(response.detailedError).toEqual('some error');
     getClaimTokensFromAttestationsSpy.and.callFake((attestations: any): { [key: string]: ClaimToken } => {
       return spiedMethod(attestations);
     });
@@ -247,17 +248,17 @@ describe('Validator', () => {
       throw new Error('some getClaimToken error');
     });
     queue.enqueueToken('siopPresentationAttestation', request);
-    result = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
-    expect(result.detailedError).toEqual('some getClaimToken error');
+    response = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
+    expect(response.detailedError).toEqual('some getClaimToken error');
 
     getClaimTokenSpy.and.callFake((): ClaimToken => {
       return <ClaimToken>{ type: <any>'test' };
     });
     queue.enqueueToken('siopPresentationAttestation', request);
     validator.tokenValidators['test'] = validator.tokenValidators['siopPresentationAttestation'];
-    result = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
-    expect(result.detailedError).toEqual(`test is not supported`);
-    expect(result.code).toEqual('VCSDKVTOR03');
+    response = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
+    expect(response.detailedError).toEqual(`test is not supported`);
+    expect(response.code).toEqual('VCSDKVTOR03');
     getClaimTokenSpy.and.callFake((queueItem: any): ClaimToken => {
       return spiedMethod(queueItem);
     });
@@ -284,9 +285,9 @@ describe('Validator', () => {
 
     const queue = new ValidationQueue();
     queue.enqueueToken('siop', request);
-    const result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.result).toBeTruthy(result.detailedError);
-    expect(result.status).toEqual(200);
+    const response = await validator.validate(queue.getNextToken()!.tokenToValidate);
+    expect(response.result).toBeTruthy(response.detailedError);
+    expect(response.status).toEqual(200);
 
   });
 
@@ -313,23 +314,23 @@ describe('Validator', () => {
 
     const queue = new ValidationQueue();
     queue.enqueueToken('siop', request);
-    const result = await validator.validate(queue.getNextToken()!.tokenToValidate);
-    expect(result.result).toBeTruthy();
-    expect(result.status).toEqual(200);
-    expect(result.detailedError).toBeUndefined();
-    expect(result.tokensToValidate).toBeUndefined();
-    expect(result.validationResult?.did).toEqual(setup.defaultUserDid);
-    expect(result.validationResult?.siopJti).toEqual(IssuanceHelpers.jti);
-    expect(result.validationResult?.siop).toBeDefined();
-    expect(result.validationResult?.verifiablePresentations).toBeDefined();
-    expect(result.validationResult?.idTokens).toBeDefined();
-    for (let idtoken in result.validationResult?.idTokens) {
-      expect(result.validationResult?.idTokens[idtoken].decodedToken.upn).toEqual('jules@pulpfiction.com');
+    const response = await validator.validate(queue.getNextToken()!.tokenToValidate);
+    expect(response.result).toBeTruthy();
+    expect(response.status).toEqual(200);
+    expect(response.detailedError).toBeUndefined();
+    expect(response.tokensToValidate).toBeUndefined();
+    expect(response.validationResult?.did).toEqual(setup.defaultUserDid);
+    expect(response.validationResult?.siopJti).toEqual(IssuanceHelpers.jti);
+    expect(response.validationResult?.siop).toBeDefined();
+    expect(response.validationResult?.verifiablePresentations).toBeDefined();
+    expect(response.validationResult?.idTokens).toBeDefined();
+    for (let idtoken in response.validationResult?.idTokens) {
+      expect(response.validationResult?.idTokens[idtoken].decodedToken.upn).toEqual('jules@pulpfiction.com');
     }
-    expect(result.validationResult?.selfIssued).toBeDefined();
-    expect(result.validationResult?.selfIssued!.decodedToken.name).toEqual('jules');
-    expect(result.validationResult?.verifiableCredentials).toBeDefined();
-    expect(result.validationResult?.verifiableCredentials!['DrivingLicense'].decodedToken.vc.credentialSubject.givenName).toEqual('Jules');
+    expect(response.validationResult?.selfIssued).toBeDefined();
+    expect(response.validationResult?.selfIssued!.decodedToken.name).toEqual('jules');
+    expect(response.validationResult?.verifiableCredentials).toBeDefined();
+    expect(response.validationResult?.verifiableCredentials!['DrivingLicense'].decodedToken.vc.credentialSubject.givenName).toEqual('Jules');
 
     // Negative cases
 
@@ -338,22 +339,22 @@ describe('Validator', () => {
   it('should read the contract id with no spaces', () => {
     const id = 'foo';
     const url = `https://test.com/v1.0/abc/def/contracts/${id}`;
-    const result = Validator.readContractId(url);
-    expect(result).toEqual(id);
+    const response = Validator.readContractId(url);
+    expect(response).toEqual(id);
   });
 
   it('should read the contract id with spaces', () => {
     const id = 'foo bar';
     const url = `https://test.com/v1.0/abc/def/contracts/${encodeURIComponent(id)}`;
-    const result = Validator.readContractId(url);
-    expect(result).toEqual(id);
+    const response = Validator.readContractId(url);
+    expect(response).toEqual(id);
   });
 
   it('should read the contract id with spaces and query', () => {
     const id = 'foo bar';
     const url = `https://test.com/v1.0/abc/def/contracts/${encodeURIComponent(id)}?qs=abcdefggh`;
-    const result = Validator.readContractId(url);
-    expect(result).toEqual(id);
+    const response = Validator.readContractId(url);
+    expect(response).toEqual(id);
   });
 
   xit('should validate a siop', async () => {
@@ -381,8 +382,8 @@ describe('Validator', () => {
 
     const req = 'your token here';
     console.log(req);
-    const result = await validator.validate(req);
-    expect(result.result).toBeTruthy();
-    expect(result.status).toEqual(200);
+    const response = await validator.validate(req);
+    expect(response.result).toBeTruthy();
+    expect(response.status).toEqual(200);
   });
 });

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -78,7 +78,7 @@ describe('Validator', () => {
     response = await validator.validate(siop.idToken.rawToken);
     expect(response.result).toBeFalsy();
     expect(response.detailedError).toEqual(`Could not fetch token configuration`);
-    expect(response.code).toEqual('VCSDKVAHE34');
+    expect(response.code).toEqual('VCSDKVaHe34');
   });
 
   it('should validate verifiable credentials', async () => {
@@ -158,7 +158,7 @@ describe('Validator', () => {
     response = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(response.result).toBeFalsy();
     expect(response.detailedError).toEqual('verifiablePresentationJwt does not has a TokenValidator');
-    expect(response.code).toEqual('VCSDKVTOR02');
+    expect(response.code).toEqual('VCSDKVtor02');
 
     // Test validator with missing VC validator
     validator = new ValidatorBuilder(crypto)
@@ -170,7 +170,7 @@ describe('Validator', () => {
     response = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(response.result).toBeFalsy();
     expect(response.detailedError).toEqual('verifiableCredential does not has a TokenValidator');
-    expect(response.code).toEqual('VCSDKVTOR02');
+    expect(response.code).toEqual('VCSDKVtor02');
   });
 
   it('should validate presentation siop', async () => {
@@ -219,7 +219,7 @@ describe('Validator', () => {
     queue.enqueueToken('siopPresentationAttestation', <any>{ claims: {} });
     response = await validator.validate(<any>queue.getNextToken()!);
     expect(response.detailedError).toEqual('Wrong token type. Expected string or ClaimToken');
-    expect(response.code).toEqual('VCSDKVTOR01');
+    expect(response.code).toEqual('VCSDKVtor01');
 
     let spiedMethod: any = ClaimToken.create;
     let createSpy: jasmine.Spy = spyOn(ClaimToken, 'create').and.callFake((): ClaimToken => {
@@ -258,7 +258,7 @@ describe('Validator', () => {
     validator.tokenValidators['test'] = validator.tokenValidators['siopPresentationAttestation'];
     response = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
     expect(response.detailedError).toEqual(`test is not supported`);
-    expect(response.code).toEqual('VCSDKVTOR03');
+    expect(response.code).toEqual('VCSDKVtor03');
     getClaimTokenSpy.and.callFake((queueItem: any): ClaimToken => {
       return spiedMethod(queueItem);
     });

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -131,6 +131,7 @@ describe('Validator', () => {
     result = vpValidator.getTokens(clonedResult, queue);
     expect(result.result).toBeFalsy(result.detailedError);
     expect(result.detailedError).toEqual('No verifiable credential');
+    expect(result.code).toEqual('VCSDKVPTV01');
 
     // Check VC validator
     queue = new ValidationQueue();
@@ -156,6 +157,7 @@ describe('Validator', () => {
     result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeFalsy();
     expect(result.detailedError).toEqual('verifiablePresentationJwt does not has a TokenValidator');
+    expect(result.code).toEqual('VCSDKVTOR02');
 
     // Test validator with missing VC validator
     validator = new ValidatorBuilder(crypto)
@@ -167,6 +169,7 @@ describe('Validator', () => {
     result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeFalsy();
     expect(result.detailedError).toEqual('verifiableCredential does not has a TokenValidator');
+    expect(result.code).toEqual('VCSDKVTOR02');
   });
 
   it('should validate presentation siop', async () => {
@@ -208,12 +211,14 @@ describe('Validator', () => {
     result = await validator.validate(queue.getNextToken()!.tokenToValidate);
     expect(result.result).toBeFalsy();
     expect(result.detailedError).toEqual(`Expected should have contractIssuers set for verifiableCredential. Missing contractIssuers for 'DrivingLicense'.`);
+    expect(result.code).toEqual('VCSDKVCVA16');
     expect(result.status).toEqual(403);
 
     // bad payload
     queue.enqueueToken('siopPresentationAttestation', <any>{ claims: {} });
     result = await validator.validate(<any>queue.getNextToken()!);
     expect(result.detailedError).toEqual('Wrong token type. Expected string or ClaimToken');
+    expect(result.code).toEqual('VCSDKVTOR01');
 
     let spiedMethod: any = ClaimToken.create;
     let createSpy: jasmine.Spy = spyOn(ClaimToken, 'create').and.callFake((): ClaimToken => {
@@ -252,6 +257,7 @@ describe('Validator', () => {
     validator.tokenValidators['test'] = validator.tokenValidators['siopPresentationAttestation'];
     result = await validator.validate(<any>queue.getNextToken()!.tokenToValidate.rawToken);
     expect(result.detailedError).toEqual(`test is not supported`);
+    expect(result.code).toEqual('VCSDKVTOR03');
     getClaimTokenSpy.and.callFake((queueItem: any): ClaimToken => {
       return spiedMethod(queueItem);
     });

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -169,7 +169,7 @@ describe('Validator', () => {
     expect(result.detailedError).toEqual('verifiableCredential does not has a TokenValidator');
   });
 
-  it('should validate presentation siop', async () => {
+  it('should validate presentation siop', async () => {    
     const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.verifiablePresentationJwt, false);
     const siopExpected = siop.expected.filter((token: IExpectedSiop) => token.type === TokenType.siopPresentationAttestation)[0];
     const vcExpected = siop.expected.filter((token: IExpectedVerifiableCredential) => token.type === TokenType.verifiableCredential)[0];

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -115,6 +115,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The vc property does not contain type`);
+    expect(response.code).toEqual('VCSDKVCVA01');
 
     // The verifiable credential vc property does not contain https://www.w3.org/2018/credentials/v1
     payload = {
@@ -132,7 +133,8 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential type property should have two elements`);
-    
+    expect(response.code).toEqual('VCSDKVCVA02');
+
     payload = {
       iss: 'did:test:issuer',
       sub: 'test',
@@ -147,6 +149,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential type first element should be VerifiableCredential`);
+    expect(response.code).toEqual('VCSDKVCVA03');
 
     payload = {
       iss: 'did:test:issuer',

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -57,12 +57,14 @@ describe('VerifiableCredentialValidation', () => {
     delete clonedExpected.contractIssuers;
     response = <VerifiableCredentialValidationResponse>VerifiableCredentialValidation.getIssuersFromExpected(clonedExpected, 'IdentityCard');
     expect(response.detailedError).toEqual('Expected should have contractIssuers set for verifyableCredential');
+    expect(response.code).toEqual('VCSDKVCVA13');
 
     // Bad VC signature
     response = await validator.validate(siop.vc.rawToken + 'a', setup.defaultUserDid);
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiableCredential is invalid');
+    expect(response.code).toEqual('VCSDKVAHE27');
 
     // Missing vc
     let payload: any = {

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -46,11 +46,13 @@ describe('VerifiableCredentialValidation', () => {
     clonedExpected = clone(expected);
     response = <VerifiableCredentialValidationResponse>VerifiableCredentialValidation.getIssuersFromExpected(clonedExpected, <any>undefined);
     expect(response.detailedError).toEqual('The credentialType needs to be specified to validate the verifiableCredential.');
+    expect(response.code).toEqual('VCSDKVCVA15');
 
     clonedExpected = clone(expected);
     clonedExpected.contractIssuers = [];
     response = <VerifiableCredentialValidationResponse>VerifiableCredentialValidation.getIssuersFromExpected(clonedExpected, 'IdentityCard');
     expect(response.detailedError).toEqual('Expected should have contractIssuers set for verifiableCredential. Empty array presented.');
+    expect(response.code).toEqual('VCSDKVCVA14');
 
     delete clonedExpected.contractIssuers;
     response = <VerifiableCredentialValidationResponse>VerifiableCredentialValidation.getIssuersFromExpected(clonedExpected, 'IdentityCard');
@@ -71,6 +73,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential vc property does not exist`);
+    expect(response.code).toEqual('VCSDKVCVA04');
 
     // Missing context
     payload = {
@@ -84,6 +87,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential vc property does not contain @context`);
+    expect(response.code).toEqual('VCSDKVCVA05');
 
     // The verifiable credential vc property does not contain https://www.w3.org/2018/credentials/v1
     payload = {
@@ -100,6 +104,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential context first element should be https://www.w3.org/2018/credentials/v1`);
+    expect(response.code).toEqual('VCSDKVCVA06');
     
     // Missing type
     payload = {
@@ -115,7 +120,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The vc property does not contain type`);
-    expect(response.code).toEqual('VCSDKVCVA01');
+    expect(response.code).toEqual('VCSDKVCVA07');
 
     // The verifiable credential vc property does not contain https://www.w3.org/2018/credentials/v1
     payload = {
@@ -133,7 +138,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential type property should have two elements`);
-    expect(response.code).toEqual('VCSDKVCVA02');
+    expect(response.code).toEqual('VCSDKVCVA07');
 
     payload = {
       iss: 'did:test:issuer',
@@ -149,7 +154,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential type first element should be VerifiableCredential`);
-    expect(response.code).toEqual('VCSDKVCVA03');
+    expect(response.code).toEqual('VCSDKVCVA07');
 
     payload = {
       iss: 'did:test:issuer',
@@ -165,6 +170,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`The verifiable credential with type 'yyy' does not has a credentialSubject property`);
+    expect(response.code).toEqual('VCSDKVCVA08');
     
     // Missing sub
     payload = {
@@ -181,6 +187,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing sub property in verifiableCredential. Expected 'did:test:user'`);
+    expect(response.code).toEqual('VCSDKVCVA09');
 
     // bad sub
     payload = {
@@ -199,5 +206,6 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong sub property in verifiableCredential. Expected 'did:test:user'`);
+    expect(response.code).toEqual('VCSDKVCVA10');
  });
 });

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -64,7 +64,7 @@ describe('VerifiableCredentialValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiableCredential is invalid');
-    expect(response.code).toEqual('VCSDKVAHE27');
+    expect(response.code).toEqual('VCSDKVaHe27');
 
     // Missing vc
     let payload: any = {

--- a/tests/VerifiablePresentationStatusReceipt.spec.ts
+++ b/tests/VerifiablePresentationStatusReceipt.spec.ts
@@ -24,6 +24,7 @@ describe('VerifiablePresentationStatusReceipt', () =>
       await verifiablePresentationStatusReceipt.validate();
     } catch (exception) {
       expect(exception.message).toEqual('The status receipt is missing receipt');
+      expect(exception.code).toEqual('VCSDKVPSC01');
     }
     let validator = verifiablePresentationStatusReceipt.didValidation;
     expect(validator.constructor.name).toEqual('DidValidation');

--- a/tests/VerifiablePresentationStatusReceipt.spec.ts
+++ b/tests/VerifiablePresentationStatusReceipt.spec.ts
@@ -36,19 +36,19 @@ describe('VerifiablePresentationStatusReceipt', () =>
 
     verifiablePresentationStatusReceipt = new VerifiablePresentationStatusReceipt({receipt: [{}]}, validatorBuilder, validationOptions, expected);
     verifiablePresentationStatusReceipt.didValidation = validator;
-    let result = await verifiablePresentationStatusReceipt.validate();
-    expect(result.result).toBeFalsy(result.detailedError);    
+    let response = await verifiablePresentationStatusReceipt.validate();
+    expect(response.result).toBeFalsy(response.detailedError);    
 
     validatorSpy.and.callFake(() => {
       return <any> {result: true, payloadObject: {aud: ''}};
     });
-    result = await verifiablePresentationStatusReceipt.validate();
-    expect(result.result).toBeFalsy(result.detailedError);    
+    response = await verifiablePresentationStatusReceipt.validate();
+    expect(response.result).toBeFalsy(response.detailedError);    
 
     validatorSpy.and.callFake(() => {
       return <any> {result: true, payloadObject: {aud: 'didAudience', issuer: ''}};
     });
-    result = await verifiablePresentationStatusReceipt.validate();
-    expect(result.result).toBeFalsy(result.detailedError);    
+    response = await verifiablePresentationStatusReceipt.validate();
+    expect(response.result).toBeFalsy(response.detailedError);    
   });
 });

--- a/tests/VerifiablePresentationValidation.spec.ts
+++ b/tests/VerifiablePresentationValidation.spec.ts
@@ -40,14 +40,14 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong iss property in verifiablePresentation. Expected 'abcdef'`);
-    expect(response.code).toEqual('VCSDKVAHE18');
+    expect(response.code).toEqual('VCSDKVaHe18');
 
     // Bad VP signature
     response = await validator.validate(siop.vp.rawToken + 'a');
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiablePresentationJwt is invalid');
-    expect(response.code).toEqual('VCSDKVAHE27');
+    expect(response.code).toEqual('VCSDKVaHe27');
 
     // Missing iss
     let payload: any = {
@@ -58,7 +58,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing iss property in verifiablePresentation. Expected 'did:test:user'`);
-    expect(response.code).toEqual('VCSDKVAHE17');
+    expect(response.code).toEqual('VCSDKVaHe17');
 
     // Bad iss
      payload = {
@@ -70,7 +70,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong iss property in verifiablePresentation. Expected 'did:test:user'`);
-    expect(response.code).toEqual('VCSDKVAHE18');
+    expect(response.code).toEqual('VCSDKVaHe18');
 
     // Missing aud
     payload = {
@@ -86,7 +86,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing aud property in verifiablePresentation. Expected 'did:test:issuer'`);
-    expect(response.code).toEqual('VCSDKVAHE19');
+    expect(response.code).toEqual('VCSDKVaHe19');
 
     // Wrong aud
     payload = {
@@ -102,7 +102,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong aud property in verifiablePresentation. Expected 'did:test:issuer'. Found 'test'`);
-    expect(response.code).toEqual('VCSDKVAHE20');
+    expect(response.code).toEqual('VCSDKVaHe20');
 
     // Missing context
     payload = {

--- a/tests/VerifiablePresentationValidation.spec.ts
+++ b/tests/VerifiablePresentationValidation.spec.ts
@@ -47,6 +47,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiablePresentationJwt is invalid');
+    expect(response.code).toEqual('VCSDKVAHE27');
 
     // Missing iss
     let payload: any = {
@@ -116,6 +117,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing or wrong default type in vp of presentation. Should be VerifiablePresentation`);
+    expect(response.code).toEqual('VCSDKVPVa03');
 
     payload.vp['@context'].type = ['VerifiablePresentation'];
     siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
@@ -123,6 +125,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing or wrong default type in vp of presentation. Should be VerifiablePresentation`);
+    expect(response.code).toEqual('VCSDKVPVa03');
 
     // Missing vc
     payload = {
@@ -138,6 +141,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing verifiableCredential in presentation`);
+    expect(response.code).toEqual('VCSDKVPVa04');
 
     // Missing vp
     payload = {
@@ -149,6 +153,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing vp in presentation`);
+    expect(response.code).toEqual('VCSDKVPVa02');
 
     // Missing context in vp
     payload = {
@@ -161,6 +166,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing @context in presentation`);
+    expect(response.code).toEqual('VCSDKVPVa03');
 
 
     // wrong did
@@ -174,5 +180,6 @@ describe('VerifiablePresentationValidation', () => {
     validator = new VerifiablePresentationValidation(options, expected, setup.defaultUserDid, 'id');
     response = await validator.validate(siop.vp.rawToken);
     expect(response.detailedError).toEqual(`The DID used for the SIOP did:test:user is not equal to the DID used for the verifiable presentation wrong did`);
+    expect(response.code).toEqual('VCSDKVPVa01');
   });
 });

--- a/tests/VerifiablePresentationValidation.spec.ts
+++ b/tests/VerifiablePresentationValidation.spec.ts
@@ -40,6 +40,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong iss property in verifiablePresentation. Expected 'abcdef'`);
+    expect(response.code).toEqual('VCSDKVAHE18');
 
     // Bad VP signature
     response = await validator.validate(siop.vp.rawToken + 'a');
@@ -56,6 +57,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing iss property in verifiablePresentation. Expected 'did:test:user'`);
+    expect(response.code).toEqual('VCSDKVAHE17');
 
     // Bad iss
      payload = {
@@ -67,7 +69,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong iss property in verifiablePresentation. Expected 'did:test:user'`);
-
+    expect(response.code).toEqual('VCSDKVAHE18');
 
     // Missing aud
     payload = {
@@ -83,6 +85,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Missing aud property in verifiablePresentation. Expected 'did:test:issuer'`);
+    expect(response.code).toEqual('VCSDKVAHE19');
 
     // Wrong aud
     payload = {
@@ -98,6 +101,7 @@ describe('VerifiablePresentationValidation', () => {
     expect(response.result).toBeFalsy();
     expect(response.status).toEqual(403);
     expect(response.detailedError).toEqual(`Wrong aud property in verifiablePresentation. Expected 'did:test:issuer'. Found 'test'`);
+    expect(response.code).toEqual('VCSDKVAHE20');
 
     // Missing context
     payload = {

--- a/tests/models/ITestModel.ts
+++ b/tests/models/ITestModel.ts
@@ -24,9 +24,14 @@ export default interface ITestModel {
     responseStatus: any;
 
     /**
-     * Define a set of operations to perform on response payload
+     * Define a set of operations to perform on response payload before signing the SIOP
      */
-    responseOperations?: any[];
+     preSiopResponseOperations?: any[];
+
+    /**
+     * Define a set of operations to perform on response payload before signing the tokens
+     */
+     preSignatureResponseOperations?: any[];
 
     /**
      * Retrieve VC

--- a/tests/models/RequestAttestationsOneVcSaIdtokenResponseNoIdToken.ts
+++ b/tests/models/RequestAttestationsOneVcSaIdtokenResponseNoIdToken.ts
@@ -8,7 +8,7 @@ import RequestAttestationsOneVcSaIdtokenResponseOk from './RequestAttestationsOn
 
 export default class RequestAttestationsOneVcSaIdtokenResponseNoIdToken extends RequestAttestationsOneVcSaIdtokenResponseOk implements ITestModel {
 
-    public responseOperations = [
+    public preSiopResponseOperations = [
         {
         path: '$.attestations.idTokens',
         operation: () => undefined

--- a/tests/models/RequestAttestationsOneVcSaIdtokenResponseOne.ts
+++ b/tests/models/RequestAttestationsOneVcSaIdtokenResponseOne.ts
@@ -8,7 +8,7 @@ import RequestAttestationsOneVcSaIdtokenResponseOk from './RequestAttestationsOn
 
 export default class RequestAttestationsOneVcSaIdtokenResponseOne extends RequestAttestationsOneVcSaIdtokenResponseOk implements ITestModel {
 
-    public responseOperations = [
+    public preSiopResponseOperations = [
         {
         path: '$.attestations.presentations.DriversLicenseCredential',
         operation: () => undefined

--- a/tests/models/RequestOneJsonLdVcResponseNoProofInVC.ts
+++ b/tests/models/RequestOneJsonLdVcResponseNoProofInVC.ts
@@ -7,7 +7,7 @@ import RequestOneJsonLdVcResponseOk from "./RequestOneJsonLdVcResponseOk";
 
 
 export default class RequestOneJsonLdVcResponseNoProofInVC extends RequestOneJsonLdVcResponseOk implements ITestModel {
-  public responseOperations = [
+  public preSiopResponseOperations = [
     {
       path: '$.presentation_submission.attestations.presentations.IdentityCard.verifiableCredential.proof',
       operation: () => undefined

--- a/tests/models/RequestOneJsonLdVcResponseWrongSiopDId.ts
+++ b/tests/models/RequestOneJsonLdVcResponseWrongSiopDId.ts
@@ -8,7 +8,7 @@ import RequestOneJsonLdVcResponseOk from './RequestOneJsonLdVcResponseOk';
 
 export default class RequestOneJsonLdVcResponseWrongSiopDId extends RequestOneJsonLdVcResponseOk implements ITestModel {
 
-  public responseOperations = [
+  public preSiopResponseOperations = [
     {
       path: '$.presentation_submission.attestations.presentations.IdentityCard.verifiableCredential.credentialSubject.id',
       operation: () => 'wrong did'

--- a/tests/models/RequestOneVcResponseMissingId.ts
+++ b/tests/models/RequestOneVcResponseMissingId.ts
@@ -8,7 +8,7 @@ import RequestOneVcResponseOk from './RequestOneVcResponseOk';
 
 export default class RequestOneVcResponseMissingId extends RequestOneVcResponseOk implements ITestModel {
 
-  public responseOperations = [
+  public preSiopResponseOperations = [
     {
       path: '$.presentation_submission.descriptor_map[0].id',
       operation: () => undefined

--- a/tests/models/RequestTwoVcPointerToMultipleTokens.ts
+++ b/tests/models/RequestTwoVcPointerToMultipleTokens.ts
@@ -7,7 +7,7 @@ import RequestTwoVcResponseOk from "./RequestTwoVcResponseOk";
 
 
 export default class RequestTwoVcPointerToMultipleTokens extends RequestTwoVcResponseOk implements ITestModel {
-  public responseOperations = [
+  public preSiopResponseOperations = [
     {
       path: '$.presentation_submission.descriptor_map[0].path',
       operation: () => '$.presentation_submission.attestations.presentations.*'

--- a/tests/models/RequestTwoVcResponseOne.ts
+++ b/tests/models/RequestTwoVcResponseOne.ts
@@ -9,7 +9,7 @@ import ITestModel from './ITestModel';
 
 export default class RequestTwoVcResponseOne extends RequestTwoVcResponseOk implements ITestModel {
 
-    public responseOperations = [
+    public preSiopResponseOperations = [
         {
         path: '$.presentation_submission.attestations.presentations.Diploma',
         operation: () => undefined


### PR DESCRIPTION
**Problem:**
Exceptions should have a unique code so callers can depend on them


**Solution:**
Add ValidationError with a unique code


**Validation:**
New unit tests

**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
