### PR TITLE
Return validationOptions from the ValidatorBuilder

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,11 @@
+# version 0.12.1-preview.0
+## Allow IValidationOptions to be specified via ValidatorBuilder
+**Type of change:** feature    
+**Customer impact:** low
+
+Removed IHttpClientOptions because not used anymore.
+VerifiablePresentationTokenValidator ctor no longer uses the crypto argument.
+
 # version 0.11.1
 ## Turn 0.11.1-preview.5 into the released package
 

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -301,7 +301,7 @@ export default class Validator {
 
           // Validate receipt
           const receipt = await response.json();
-          const validatorOption: IValidatorOptions = this.setValidatorOptions();
+          const validatorOption: IValidatorOptions = this.builder.validationOptions;
           const options = new ValidationOptions(validatorOption, TokenType.siopPresentationExchange);
           const receiptValidator = new VerifiablePresentationStatusReceipt(receipt, this.builder, options, <IExpectedStatusReceipt>{ didIssuer: vcIssuerDid, didAudience: this.builder.crypto.builder.did });
           const receipts = await receiptValidator.validate();
@@ -322,17 +322,6 @@ export default class Validator {
     }
 
     return validationResponse;
-  }
-
-  /**
-   * Set the validator options
-   */
-  private setValidatorOptions(): IValidatorOptions {
-    return {
-      fetchRequest:this.builder.fetchRequest,
-      resolver: this.builder.resolver,
-      crypto: this.builder.crypto
-    }
   }
 
   private isSiop(type: TokenType | undefined) {

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -45,7 +45,18 @@ export default class ValidatorBuilder {
   public build(): Validator {
     return new Validator(this);
   }
-  
+
+  /**
+   * Gets the validation options
+   */
+  public get validationOptions(): IValidatorOptions {
+    return {
+      resolver: this.resolver,
+      fetchRequest: this.fetchRequest,
+      crypto: this.crypto
+    };
+  }
+
  /**
    * Sets the state
    * @param state The state for the response
@@ -133,17 +144,13 @@ export default class ValidatorBuilder {
   public get tokenValidators(): { [type: string]: ITokenValidator } {
     // check if default validators need to be instantiated
     if (!this._tokenValidators) {
-      const validatorOptions: IValidatorOptions = {
-        fetchRequest: this.fetchRequest,
-        resolver: this.resolver,
-        crypto: this._crypto
-      };
+      const validatorOptions: IValidatorOptions = this.validationOptions;
 
       this._tokenValidators = {
         selfIssued: new SelfIssuedTokenValidator(validatorOptions, <IExpectedSelfIssued> {type: TokenType.selfIssued}),
         idToken: new IdTokenTokenValidator(validatorOptions, <IExpectedIdToken> {type: TokenType.idToken, configuration: this._trustedIssuerConfigurationsForIdTokens}),
         verifiableCredential: new VerifiableCredentialTokenValidator(validatorOptions, <IExpectedVerifiableCredential> {type: TokenType.verifiableCredential, contractIssuers: this._trustedIssuersForVerifiableCredentials}),
-        verifiablePresentationJwt: new VerifiablePresentationTokenValidator(validatorOptions, this.crypto, <IExpectedVerifiablePresentation> {type: TokenType.verifiablePresentationJwt, didAudience: this.crypto.builder.did}),
+        verifiablePresentationJwt: new VerifiablePresentationTokenValidator(validatorOptions, <IExpectedVerifiablePresentation> {type: TokenType.verifiablePresentationJwt, didAudience: this.crypto.builder.did}),
         siopPresentationAttestation: new SiopTokenValidator(validatorOptions, <IExpectedSiop> {type: TokenType.siopPresentationAttestation, audience: this._audienceUrl}),
         siop: new SiopTokenValidator(validatorOptions, <IExpectedSiop> {type: TokenType.siop, audience: this._audienceUrl}),
         siopPresentationExchange: new SiopTokenValidator(validatorOptions, <IExpectedSiop> {type: TokenType.siopPresentationExchange, audience: this._audienceUrl}),
@@ -198,13 +205,8 @@ export default class ValidatorBuilder {
       // Make sure existing expected gets updated
       const vcValidator = this._tokenValidators[TokenType.verifiableCredential];
       if (vcValidator) {
-        const validatorOptions: IValidatorOptions = {
-          fetchRequest: this.fetchRequest,
-          resolver: this.resolver,
-          crypto: this._crypto
-        };
         const expected: IExpectedVerifiableCredential = {type: TokenType.verifiableCredential, contractIssuers: issuers};
-        this._tokenValidators[TokenType.verifiableCredential] = new VerifiableCredentialTokenValidator(validatorOptions, expected);
+        this._tokenValidators[TokenType.verifiableCredential] = new VerifiableCredentialTokenValidator(this.validationOptions, expected);
       }
     }
     return this;
@@ -228,13 +230,8 @@ export default class ValidatorBuilder {
       // Make sure existing expected gets updated
       const idtokenValidator = this._tokenValidators[TokenType.idToken];
       if (idtokenValidator) {
-        const validatorOptions: IValidatorOptions = {
-          fetchRequest: this.fetchRequest,
-          resolver: this.resolver,
-          crypto: this._crypto
-        };
         const expected: IExpectedIdToken = {type: TokenType.idToken, configuration: issuers};
-        this._tokenValidators[TokenType.idToken] = new IdTokenTokenValidator(validatorOptions, expected);
+        this._tokenValidators[TokenType.idToken] = new IdTokenTokenValidator(this.validationOptions, expected);
       }
     }
     return this;

--- a/lib/api_validation/VerifiablePresentationTokenValidator.ts
+++ b/lib/api_validation/VerifiablePresentationTokenValidator.ts
@@ -22,7 +22,7 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
    * @param validatorOption The options used during validation
    * @param expected values to find in the token to validate
    */
-  constructor (private validatorOption: IValidatorOptions, private crypto: Crypto, private expected: IExpectedVerifiablePresentation ) {
+   constructor (private validatorOption: IValidatorOptions, private expected: IExpectedVerifiablePresentation ) {
   }
 
   /**

--- a/lib/options/BasicValidatorOptions.ts
+++ b/lib/options/BasicValidatorOptions.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { Crypto, IDidResolver, CryptoBuilder, IFetchRequest, FetchRequest } from '../index';
 import IValidatorOptions from './IValidatorOptions';
-import { IHttpClientOptions } from "./IValidatorOptions";
 
 /**
  * Basic IValidatorOptions implementation

--- a/lib/options/IValidatorOptions.ts
+++ b/lib/options/IValidatorOptions.ts
@@ -6,17 +6,6 @@
 import { IDidResolver, Crypto } from '../index';
 import IFetchRequest from '../tracing/IFetchRequest';
 
-/**
- * Interface to model the fetch options
- */
-export interface IHttpClientOptions {
-
-    /**
-     * The http client options
-     */
-    options: any,
-}
-
  /**
  * Interface to model the validator options
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.11.1",
+  "version": "0.12.1-preview.0",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/SiopTokenValidator.spec.ts
+++ b/tests/SiopTokenValidator.spec.ts
@@ -21,8 +21,7 @@ describe('SiopTokenValidator', () => {
   it('should test nonce and state', async () => {
     const [request, options, siop] = await IssuanceHelpers.createRequest(setup, TokenType.siopIssuance, true);
     const expected: IExpectedSiop = siop.expected.filter((token: IExpectedSiop) => token.type === TokenType.siopIssuance)[0];
-    const validationOptions = new ValidationOptions(setup.validatorOptions, TokenType.siopIssuance);
-
+    
     let validator = new SiopTokenValidator(setup.validatorOptions, expected);
     let payload: any = {
       ...request.decodedToken,

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -108,7 +108,7 @@ describe('Validator', () => {
     };
     map[vcAttestationName] = vcExpected;
 
-    const vpValidator = new VerifiablePresentationTokenValidator(setup.validatorOptions, crypto, vpExpected);
+    const vpValidator = new VerifiablePresentationTokenValidator(setup.validatorOptions, vpExpected);
     const vcValidator = new VerifiableCredentialTokenValidator(setup.validatorOptions, map);
     let validator = new ValidatorBuilder(crypto)
       .useValidators([vcValidator, vpValidator])

--- a/tests/ValidatorBuilder.spec.ts
+++ b/tests/ValidatorBuilder.spec.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Crypto, ValidatorBuilder, CryptoBuilder, ManagedHttpResolver, RequestorBuilder, BasicValidatorOptions } from '../lib/index';
+import { Crypto, ValidatorBuilder, CryptoBuilder, ManagedHttpResolver, RequestorBuilder, BasicValidatorOptions, FetchRequest } from '../lib/index';
 
 describe('ValidatorBuilder', () => {
   it('should test status feature flag', () => {
@@ -13,6 +13,18 @@ describe('ValidatorBuilder', () => {
 
     builder = builder.enableFeatureVerifiedCredentialsStatusCheck(false);
     expect(builder.featureVerifiedCredentialsStatusCheckEnabled).toBeFalsy();
+  });
+
+  it('should return validationOptions', () => {
+    const resolver = new ManagedHttpResolver('https://example.com');
+    const fetchRequest = new FetchRequest();
+    const options = new BasicValidatorOptions();
+    let builder = new ValidatorBuilder(options.crypto)
+      .useFetchRequest(fetchRequest)
+      .useResolver(resolver);
+    expect(builder.crypto).toEqual(builder.validationOptions.crypto);
+    expect(builder.fetchRequest).toEqual(builder.validationOptions.fetchRequest);
+    expect(builder.resolver).toEqual(builder.validationOptions.resolver);
   });
 
   it('should use new resolver', () => {


### PR DESCRIPTION
**Problem:**
IValidatorOptions can be returned from the state of ValidatorBuilder. 
Removed unused crypto parameter from VerifiablePresentationTokenValidator. 

**Solution:**
Add the validatorOptions property to the builder


**Validation:**
New unit test

**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

