### PR TITLE
Beejones/bug resolver is not using fetch request

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,10 +1,28 @@
 # version 0.12.1-preview.0
+## Add error codes to the validation response
+**Type of change:** engineering    
+**Customer impact:** low
+The validation response return code, a string which contains a unique value for the error.
+The error code is fixed in unit tests
+
+    console.log(validationResponse.code); // for seeing the code
+    console.log(validationResponse.status); // for seeing the suggested status to return to client
+    console.log(validationResponse.detailedError); // for seeing the detailed error message
+
+
 ## Allow IValidationOptions to be specified via ValidatorBuilder
 **Type of change:** feature    
 **Customer impact:** low
 
-Removed IHttpClientOptions because not used anymore.
+Removed IHttpClientOptions because it is not used anymore.
+
 VerifiablePresentationTokenValidator ctor no longer uses the crypto argument.
+
+Add validationOptions property to ValidatorBuilder
+
+    // Retrieve the validator options from the builder state
+    const options = validationBuilder.validationOptions;  
+
 
 # version 0.11.1
 ## Turn 0.11.1-preview.5 into the released package

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -154,6 +154,7 @@ export class ValidationHelpers {
     const self: any = this;
     try {
       const resolveResult: IDidResolveResult = await (self as ValidationOptions).validatorOptions.resolver.resolve(validationResponse.did as string);
+
       if (!resolveResult || !resolveResult.didDocument) {
         return validationResponse = {
           result: false,

--- a/lib/resolver/ManagedHttpResolver.ts
+++ b/lib/resolver/ManagedHttpResolver.ts
@@ -17,9 +17,11 @@ export default class ManagedHttpResolver implements IDidResolver {
   public readonly resolverUrl: string;
 
   /**
+   * Create an instance of ManagedHttpResolver
    * @param universalResolverUrl the URL endpoint of the remote universal resolvers
+   * @param fetchRequest optional fetch client
    */
-  constructor(universalResolverUrl: string) {
+  constructor(universalResolverUrl: string, private fetchRequest?: IFetchRequest) {
     // Format and set the property for the
     const slash = universalResolverUrl.endsWith('/') ? '' : '/';
     this.resolverUrl = `${universalResolverUrl}${slash}`;
@@ -29,14 +31,14 @@ export default class ManagedHttpResolver implements IDidResolver {
    * Looks up a DID Document
    * @inheritdoc
    */
-  public async resolve(did: string, fetchRequest?: IFetchRequest): Promise<IDidResolveResult> {
+  public async resolve(did: string): Promise<IDidResolveResult> {
     const query = `${this.resolverUrl}${did}`;
     let response: Response;
-    if (!fetchRequest) {
-      fetchRequest = new FetchRequest();
+    if (!this.fetchRequest) {
+      this.fetchRequest = new FetchRequest();
     }
 
-    response = await fetchRequest.fetch(query, 'DIDResolve', {
+    response = await this.fetchRequest.fetch(query, 'DIDResolve', {
       method: 'GET',
       headers: {
       }

--- a/tests/ManagedHttpResolver.spec.ts
+++ b/tests/ManagedHttpResolver.spec.ts
@@ -38,9 +38,9 @@ const fetchMock = require('fetch-mock');
       });
 
       const fetchRequest = new FetchRequest();
-      const resolver = new ManagedHttpResolver('https://resolver');
+      const resolver = new ManagedHttpResolver('https://resolver', fetchRequest);
       await resolver.resolve('did');
-      await resolver.resolve('did', fetchRequest);
+      await resolver.resolve('did');
       expect(called).toBeTruthy();
 
       // Negative cases
@@ -48,7 +48,7 @@ const fetchMock = require('fetch-mock');
         return { status: 404 };
        }, { overwriteRoutes: true });
        try {
-        await resolver.resolve('did', fetchRequest);
+        await resolver.resolve('did');
         fail('exception on resolve was  not thrown');
        } catch (exception) {
          expect(exception).toEqual(new Error('Could not resolve https://resolver/did'));


### PR DESCRIPTION
**Problem:**
The resolve caller did not pass the fetchRequest to resolve


**Solution:**
Refactor so fetchRequest can be passed in the constructure


**Validation:**
Updated unit tests

**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

