### PR TITLE
Beejones/add validation safeguards

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -4,6 +4,55 @@
 **Customer impact:** low
 - Protection against attack vector.
 
+## Add Validation safeguards
+**Type of change:** feature work
+**Customer impact:** low
+
+A new class ValidationSafeguards is added. The safeguards can be set via the ValidationBuilder.
+Several new properties are added to the builder.
+
+  /**
+   * Gets the maximum number of VC tokens in a SIOP presentation
+   */
+  public get maxNumberOfVCTokensInPresentation()
+
+  /**
+   * Sets the maximum number of VC tokens in a SIOP presentation
+   */
+  public useMaxNumberOfVCTokensInPresentation(value: number): ValidatorBuilder 
+
+  /**
+   * Gets the maximum size of VP tokens in a SIOP
+   */
+  public get maxSizeOfVPTokensInSiop()
+
+  /**
+   * Sets the maximum size of VP tokens in a SIOP
+   */
+  public useMaxSizeOfVPTokensInSiop(value: number): ValidatorBuilder 
+
+  /**
+   * Gets the maximum size of VC tokens in a presentation
+   */
+  public get maxSizeOfVCTokensInPresentation() 
+
+  /**
+   * Sets the maximum size of VC tokens in a presentation
+   */
+  public useMaxSizeOfVCTokensInPresentation(value: number): ValidatorBuilder 
+
+  /**
+   * Gets the maximum size of ID tokens
+   */
+  public get maxSizeOfIdToken() 
+
+  /**
+   * Sets the maximum size of ID tokens
+   */
+  public useMaxSizeOfIdToken(value: number): ValidatorBuilder 
+
+
+
 # version 0.12.1-preview.5
 ## Support IdToken Hint Tokens
 **Type of change:** feature work

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -135,6 +135,9 @@ export default class SiopTokenValidator implements ITokenValidator {
             code: errorCode(5)
         };
     }
+    // Validation gate: Test for maximum number of presentations and maximum size
+
+    // Add tokens to queue
     if (validationResponse.tokensToValidate) {
       for (let key in validationResponse.tokensToValidate) {
         queue.enqueueItem(new ValidationQueueItem(key, validationResponse.tokensToValidate[key]));

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -123,28 +123,90 @@ export default class SiopTokenValidator implements ITokenValidator {
             detailedError: err.message,
             code: errorCode(4),
             innerError: err
-        };
+          };
         }
         break;
 
       default:
-          return {
-            result: false,
-            status: 400,
-            detailedError: 'Not a valid SIOP',
-            code: errorCode(5)
+        return {
+          result: false,
+          status: 400,
+          detailedError: 'Not a valid SIOP',
+          code: errorCode(5)
         };
     }
-    
-    // Validation gate: Test for maximum number of VPs and maximum size
 
+    // Validation gate: Test for maximum number of VPs and maximum size
     // Add tokens to queue
     if (validationResponse.tokensToValidate) {
+      const safeguards = this.validateSafeguards(validationResponse.tokensToValidate);
+      if (!safeguards.result) {
+        return safeguards;
+      }
+
       for (let key in validationResponse.tokensToValidate) {
         queue.enqueueItem(new ValidationQueueItem(key, validationResponse.tokensToValidate[key]));
       }
     }
     return validationResponse;
+  }
+
+  /**
+   * Check the safeguards on the tokens in the SIOP
+   * @param claimTokens in the SIOP
+   * @returns true if safeguards pass
+   */
+  private validateSafeguards(claimTokens: { [key: string]: ClaimToken }): IValidationResponse {
+    if (claimTokens) {
+      // Validation gate: Test for maximum number of VPs and maximum size
+      const validatorSafeguards = this.validatorOption.validationSafeguards;
+      let tokens = Object.values(claimTokens);
+      const vpInSiop = tokens.filter((claimToken: ClaimToken) => claimToken.type === TokenType.verifiablePresentationJwt);
+      if (vpInSiop.length > validatorSafeguards.maxNumberOfVPTokensInSiop) {
+        return {
+          result: false,
+          status: 403,
+          code: errorCode(6),
+          detailedError: `The number of presentations in the SIOP ${vpInSiop.length} exceeds the maximum ${validatorSafeguards.maxNumberOfVPTokensInSiop}.`
+        }
+      }
+
+      let oversized = tokens.filter((claimToken: ClaimToken) => typeof claimToken.rawToken === 'string' && claimToken.rawToken.length > validatorSafeguards.maxSizeOfVPTokensInSiop);
+      if (oversized.length !== 0) {
+        return {
+          result: false,
+          status: 403,
+          code: errorCode(7),
+          detailedError: `The SIOP has an oversized VP tokens. Size ${(<string>oversized[0].rawToken).length}. Maximum size: ${validatorSafeguards.maxSizeOfVPTokensInSiop}.`
+        }
+      }
+
+      // Validation gate: Test for maximum number of id tokens and maximum size
+      tokens = Object.values(claimTokens);
+      const idTokensInSiop = tokens.filter((claimToken: ClaimToken) => claimToken.type === TokenType.idToken);
+      if (idTokensInSiop.length > validatorSafeguards.maxNumberOfIdTokensInSiop) {
+        return {
+          result: false,
+          status: 403,
+          code: errorCode(8),
+          detailedError: `The number of id tokens in the SIOP ${idTokensInSiop.length} exceeds the maximum ${validatorSafeguards.maxNumberOfIdTokensInSiop}.`
+        }
+      }
+
+      oversized = tokens.filter((claimToken: ClaimToken) => typeof claimToken.rawToken === 'string' && claimToken.rawToken.length > validatorSafeguards.maxSizeOfIdToken);
+      if (oversized.length !== 0) {
+        return {
+          result: false,
+          status: 403,
+          code: errorCode(9),
+          detailedError: `The SIOP has an oversized Id tokens. Size ${(<string>oversized[0].rawToken).length}. Maximum size: ${validatorSafeguards.maxSizeOfIdToken}.`
+        }
+      }
+    }
+
+    return <IValidationResponse>{
+      result: true
+    }
   }
 
   /**

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -135,7 +135,8 @@ export default class SiopTokenValidator implements ITokenValidator {
             code: errorCode(5)
         };
     }
-    // Validation gate: Test for maximum number of presentations and maximum size
+    
+    // Validation gate: Test for maximum number of VPs and maximum size
 
     // Add tokens to queue
     if (validationResponse.tokensToValidate) {

--- a/lib/api_validation/ValidationSafeguards.ts
+++ b/lib/api_validation/ValidationSafeguards.ts
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Interface defining all safeguards for validation
+ */
+export interface IValidationSafeguards {
+  maxNumberOfVPTokensInSiop: number,
+  maxSizeOfVPTokensInSiop: number,
+  maxNumberOfVCTokensInPresentation: number,
+  maxSizeOfVCTokensInPresentation: number,
+  maxNumberOfIdTokensInSiop: number,
+  maxSizeOfIdToken: number
+}
+
+/**
+ * Class to define the safeguards used during validation of tokens
+ */
+export default class ValidationSafeguards {
+
+  private _maxNumberOfVPTokensInSiop: number;
+  private _maxSizeOfVPTokensInSiop: number;
+  private _maxNumberOfVCTokensInPresentation: number;
+  private _maxSizeOfVCTokensInPresentation: number;
+  private _maxNumberOfIdTokensInSiop: number;
+  private _maxSizeOfIdToken: number;
+
+  constructor(safeguards?: IValidationSafeguards) {
+    this._maxNumberOfVPTokensInSiop = safeguards?.maxNumberOfVPTokensInSiop || 10;
+    this._maxSizeOfVPTokensInSiop = safeguards?.maxSizeOfVPTokensInSiop || 16 * 1024 * 1024;
+    this._maxNumberOfVCTokensInPresentation = safeguards?.maxNumberOfVCTokensInPresentation || 1;
+    this._maxSizeOfVCTokensInPresentation = safeguards?.maxSizeOfVCTokensInPresentation || 16 * 1024 * 1024;
+    this._maxNumberOfIdTokensInSiop = safeguards?.maxNumberOfIdTokensInSiop || 1;
+    this._maxSizeOfIdToken = safeguards?.maxSizeOfIdToken || 16 * 1024 * 1024;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxNumberOfVPTokensInSiop() {
+    return this._maxNumberOfVPTokensInSiop;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set maxNumberOfVPTokensInSiop(value: number) {
+    this._maxNumberOfVPTokensInSiop = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxNumberOfVCTokensInPresentation() {
+    return this._maxNumberOfVCTokensInPresentation;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set maxNumberOfVCTokensInPresentation(value: number) {
+    this._maxNumberOfVCTokensInPresentation = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxSizeOfVPTokensInSiop() {
+    return this._maxSizeOfVPTokensInSiop;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set maxSizeOfVPTokensInSiop(value: number) {
+    this._maxSizeOfVPTokensInSiop = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxSizeOfVCTokensInPresentation() {
+    return this._maxSizeOfVCTokensInPresentation;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set maxSizeOfVCTokensInPresentation(value: number) {
+    this._maxSizeOfVCTokensInPresentation = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxNumberOfIdTokensInSiop() {
+    return this._maxNumberOfIdTokensInSiop;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set maxNumberOfIdTokensInSiop(value: number) {
+    this._maxNumberOfIdTokensInSiop = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxSizeOfIdToken() {
+    return this._maxSizeOfIdToken;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set maxSizeOfIdToken(value: number) {
+    this._maxSizeOfIdToken = value;
+  }
+}

--- a/lib/api_validation/ValidationSafeguards.ts
+++ b/lib/api_validation/ValidationSafeguards.ts
@@ -7,12 +7,12 @@
  * Interface defining all safeguards for validation
  */
 export interface IValidationSafeguards {
-  maxNumberOfVPTokensInSiop: number,
-  maxSizeOfVPTokensInSiop: number,
-  maxNumberOfVCTokensInPresentation: number,
-  maxSizeOfVCTokensInPresentation: number,
-  maxNumberOfIdTokensInSiop: number,
-  maxSizeOfIdToken: number
+  maxNumberOfVPTokensInSiop?: number,
+  maxSizeOfVPTokensInSiop?: number,
+  maxNumberOfVCTokensInPresentation?: number,
+  maxSizeOfVCTokensInPresentation?: number,
+  maxNumberOfIdTokensInSiop?: number,
+  maxSizeOfIdToken?: number
 }
 
 /**
@@ -32,7 +32,7 @@ export default class ValidationSafeguards {
     this._maxSizeOfVPTokensInSiop = safeguards?.maxSizeOfVPTokensInSiop || 16 * 1024 * 1024;
     this._maxNumberOfVCTokensInPresentation = safeguards?.maxNumberOfVCTokensInPresentation || 1;
     this._maxSizeOfVCTokensInPresentation = safeguards?.maxSizeOfVCTokensInPresentation || 16 * 1024 * 1024;
-    this._maxNumberOfIdTokensInSiop = safeguards?.maxNumberOfIdTokensInSiop || 1;
+    this._maxNumberOfIdTokensInSiop = safeguards?.maxNumberOfIdTokensInSiop || 5;
     this._maxSizeOfIdToken = safeguards?.maxSizeOfIdToken || 16 * 1024 * 1024;
   }
 

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ITokenValidator, Validator, IDidResolver, ManagedHttpResolver, VerifiablePresentationTokenValidator, VerifiableCredentialTokenValidator, IdTokenTokenValidator, SiopTokenValidator, SelfIssuedTokenValidator, TokenType, IValidatorOptions, IRequestor, Requestor } from '../index';
+import { ITokenValidator, Validator, IDidResolver, ManagedHttpResolver, VerifiablePresentationTokenValidator, VerifiableCredentialTokenValidator, IdTokenTokenValidator, SiopTokenValidator, SelfIssuedTokenValidator, TokenType, IValidatorOptions, IRequestor, Requestor, ValidationSafeguards } from '../index';
 import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
 import { Crypto } from '../index';
 import { IExpectedIdToken, IExpectedSelfIssued, IExpectedVerifiableCredential, IExpectedVerifiablePresentation, IExpectedSiop, IssuerMap } from '../options/IExpected';
@@ -24,6 +24,7 @@ export default class ValidatorBuilder {
   private _nonce: string | undefined;
   private _fetchRequest: IFetchRequest = new FetchRequest();
   private _resolver: IDidResolver = new ManagedHttpResolver(VerifiableCredentialConstants.UNIVERSAL_RESOLVER_URL, this._fetchRequest);
+  private _validationSafeguards: ValidationSafeguards = new ValidationSafeguards();
 
   /**
    * Create a new instance of ValidatorBuilder
@@ -263,6 +264,62 @@ export default class ValidatorBuilder {
     return this._audienceUrl;
   }
 
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxNumberOfVCTokensInPresentation() {
+    return this._validationSafeguards.maxNumberOfVCTokensInPresentation;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set useMaxNumberOfVCTokensInPresentation(value: number) {
+    this._validationSafeguards.maxNumberOfVCTokensInPresentation = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxSizeOfVPTokensInSiop() {
+    return this._validationSafeguards.maxSizeOfVPTokensInSiop;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set useMaxSizeOfVPTokensInSiop(value: number) {
+    this._validationSafeguards.maxSizeOfVPTokensInSiop = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxSizeOfVCTokensInPresentation() {
+    return this._validationSafeguards.maxSizeOfVCTokensInPresentation;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set useMaxSizeOfVCTokensInPresentation(value: number) {
+    this._validationSafeguards.maxSizeOfVCTokensInPresentation = value;
+  }
+
+  /**
+   * Gets the maximum number of VP tokens in a SIOP
+   */
+  public get maxSizeOfIdToken() {
+    return this._validationSafeguards.maxSizeOfIdToken;
+  }
+
+  /**
+   * Sets the maximum number of VP tokens in a SIOP
+   */
+  public set useMaxSizeOfIdToken(value: number) {
+    this._validationSafeguards.maxSizeOfIdToken = value;
+  }
+
   // Feature flags. Used temporary to introduce a new feature
   private _enableVerifiedCredentialsStatusCheck = true;
   public get featureVerifiedCredentialsStatusCheckEnabled(): boolean {
@@ -273,6 +330,5 @@ export default class ValidatorBuilder {
     this._enableVerifiedCredentialsStatusCheck = enable;
     return this;
   }
-
 }
 

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -299,6 +299,8 @@ export default class ValidatorBuilder {
    * Gets the maximum number of VP tokens in a SIOP
    */
   public get maxSizeOfVCTokensInPresentation() {
+    //const nrTokens = Object.keys(this.useTrustedIssuersForVerifiableCredentials).length;
+    //return this._validationSafeguards.maxSizeOfVCTokensInPresentation = nrTokens;
     return this._validationSafeguards.maxSizeOfVCTokensInPresentation;
   }
 

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -266,14 +266,14 @@ export default class ValidatorBuilder {
   }
 
   /**
-   * Gets the maximum number of VP tokens in a SIOP
+   * Gets the maximum number of VC tokens in a SIOP presentation
    */
   public get maxNumberOfVCTokensInPresentation() {
     return this._validationSafeguards.maxNumberOfVCTokensInPresentation;
   }
 
   /**
-   * Sets the maximum number of VP tokens in a SIOP
+   * Sets the maximum number of VC tokens in a SIOP presentation
    */
   public useMaxNumberOfVCTokensInPresentation(value: number): ValidatorBuilder {
     this._validationSafeguards.maxNumberOfVCTokensInPresentation = value;
@@ -281,14 +281,14 @@ export default class ValidatorBuilder {
   }
 
   /**
-   * Gets the maximum number of VP tokens in a SIOP
+   * Gets the maximum size of VP tokens in a SIOP
    */
   public get maxSizeOfVPTokensInSiop() {
     return this._validationSafeguards.maxSizeOfVPTokensInSiop;
   }
 
   /**
-   * Sets the maximum number of VP tokens in a SIOP
+   * Sets the maximum size of VP tokens in a SIOP
    */
   public useMaxSizeOfVPTokensInSiop(value: number): ValidatorBuilder {
     this._validationSafeguards.maxSizeOfVPTokensInSiop = value;
@@ -296,7 +296,7 @@ export default class ValidatorBuilder {
   }
 
   /**
-   * Gets the maximum number of VP tokens in a SIOP
+   * Gets the maximum size of VC tokens in a presentation
    */
   public get maxSizeOfVCTokensInPresentation() {
     //const nrTokens = Object.keys(this.useTrustedIssuersForVerifiableCredentials).length;
@@ -305,7 +305,7 @@ export default class ValidatorBuilder {
   }
 
   /**
-   * Sets the maximum number of VP tokens in a SIOP
+   * Sets the maximum size of VC tokens in a presentation
    */
   public useMaxSizeOfVCTokensInPresentation(value: number): ValidatorBuilder {
     this._validationSafeguards.maxSizeOfVCTokensInPresentation = value;
@@ -313,14 +313,14 @@ export default class ValidatorBuilder {
   }
 
   /**
-   * Gets the maximum number of VP tokens in a SIOP
+   * Gets the maximum size of ID tokens
    */
   public get maxSizeOfIdToken() {
     return this._validationSafeguards.maxSizeOfIdToken;
   }
 
   /**
-   * Sets the maximum number of VP tokens in a SIOP
+   * Sets the maximum size of ID tokens
    */
   public useMaxSizeOfIdToken(value: number): ValidatorBuilder {
     this._validationSafeguards.maxSizeOfIdToken = value;

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -54,6 +54,7 @@ export default class ValidatorBuilder {
     return {
       resolver: this.resolver,
       fetchRequest: this.fetchRequest,
+      validationSafeguards: this._validationSafeguards,
       crypto: this.crypto
     };
   }
@@ -274,8 +275,9 @@ export default class ValidatorBuilder {
   /**
    * Sets the maximum number of VP tokens in a SIOP
    */
-  public set useMaxNumberOfVCTokensInPresentation(value: number) {
+  public useMaxNumberOfVCTokensInPresentation(value: number): ValidatorBuilder {
     this._validationSafeguards.maxNumberOfVCTokensInPresentation = value;
+    return this;
   }
 
   /**
@@ -288,8 +290,9 @@ export default class ValidatorBuilder {
   /**
    * Sets the maximum number of VP tokens in a SIOP
    */
-  public set useMaxSizeOfVPTokensInSiop(value: number) {
+  public useMaxSizeOfVPTokensInSiop(value: number): ValidatorBuilder {
     this._validationSafeguards.maxSizeOfVPTokensInSiop = value;
+    return this;
   }
 
   /**
@@ -302,8 +305,9 @@ export default class ValidatorBuilder {
   /**
    * Sets the maximum number of VP tokens in a SIOP
    */
-  public set useMaxSizeOfVCTokensInPresentation(value: number) {
+  public useMaxSizeOfVCTokensInPresentation(value: number): ValidatorBuilder {
     this._validationSafeguards.maxSizeOfVCTokensInPresentation = value;
+    return this;
   }
 
   /**
@@ -316,8 +320,9 @@ export default class ValidatorBuilder {
   /**
    * Sets the maximum number of VP tokens in a SIOP
    */
-  public set useMaxSizeOfIdToken(value: number) {
+  public useMaxSizeOfIdToken(value: number): ValidatorBuilder {
     this._validationSafeguards.maxSizeOfIdToken = value;
+    return this;
   }
 
   // Feature flags. Used temporary to introduce a new feature

--- a/lib/api_validation/VerifiablePresentationTokenValidator.ts
+++ b/lib/api_validation/VerifiablePresentationTokenValidator.ts
@@ -75,13 +75,13 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
         }
       }
 
-      let oversized = vc.filter((claimToken: ClaimToken) => typeof claimToken.rawToken === 'string' && claimToken.rawToken.length > validatorSafeguards.maxSizeOfVCTokensInPresentation);
+      let oversized = vc.filter((token: string) => token.length > validatorSafeguards.maxSizeOfVCTokensInPresentation);
       if (oversized.length !== 0) {
         return {
           result: false,
           status: 403,
           code: errorCode(3),
-          detailedError: `The presentation has an oversized VC tokens. Size ${(<string>oversized[0].rawToken).length}. Maximum size: ${validatorSafeguards.maxSizeOfVCTokensInPresentation}.`
+          detailedError: `The presentation has an oversized VC tokens. Size ${oversized[0].length}. Maximum size: ${validatorSafeguards.maxSizeOfVCTokensInPresentation}.`
         }
       }
 
@@ -92,7 +92,7 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
         queue.enqueueToken(vcType, claimToken);
       }
     }
-    
+
     return validationResponse;
   }
 

--- a/lib/api_validation/VerifiablePresentationTokenValidator.ts
+++ b/lib/api_validation/VerifiablePresentationTokenValidator.ts
@@ -24,7 +24,7 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
    * @param validatorOption The options used during validation
    * @param expected values to find in the token to validate
    */
-   constructor (private validatorOption: IValidatorOptions, private expected: IExpectedVerifiablePresentation ) {
+  constructor(private validatorOption: IValidatorOptions, private expected: IExpectedVerifiablePresentation) {
   }
 
   /**
@@ -33,7 +33,7 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
    * @param queueItem under validation
    * @param siopDid needs to be equal to audience of VP
    */
-  public async validate(queue: ValidationQueue, queueItem: ValidationQueueItem, siopDid: string): Promise<IValidationResponse> { 
+  public async validate(queue: ValidationQueue, queueItem: ValidationQueueItem, siopDid: string): Promise<IValidationResponse> {
     const options = new ValidationOptions(this.validatorOption, TokenType.verifiablePresentationJwt);
     const validator = new VerifiablePresentationValidation(options, this.expected, siopDid, queueItem.id);
     let validationResult = await validator.validate(<string>queueItem.tokenToValidate.rawToken);
@@ -44,13 +44,13 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
 
     return validationResult as IValidationResponse;
   }
-  
+
   /**
    * Get tokens from current item and add them to the queue.
    * @param validationResponse The response for the requestor
    * @param queue with tokens to validate
    */
-  public getTokens(validationResponse: IValidationResponse, queue: ValidationQueue ): IValidationResponse {
+  public getTokens(validationResponse: IValidationResponse, queue: ValidationQueue): IValidationResponse {
     if (!validationResponse.payloadObject.vp || !validationResponse.payloadObject.vp.verifiableCredential) {
       return {
         result: false,
@@ -61,15 +61,38 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
     }
 
     // Validation gate: Test for maximum number of VCs and maximum size
-    const vc = validationResponse.payloadObject.vp.verifiableCredential;
+    const vc: any[] = validationResponse.payloadObject.vp.verifiableCredential;
     validationResponse.tokensToValidate = {};
-    for (let token in vc) {
-      const claimToken = ClaimToken.create(vc[token]);
-      const vcType = VerifiableCredentialValidation.getVerifiableCredentialType(claimToken.decodedToken.vc || claimToken.decodedToken);
-      validationResponse.tokensToValidate[vcType] = claimToken; 
-      queue.enqueueToken(vcType, claimToken);    
-    }
+    if (vc) {
+      // Validation gate: Test for maximum number of VPs and maximum size
+      const validatorSafeguards = this.validatorOption.validationSafeguards;
+      if (vc.length > validatorSafeguards.maxNumberOfVCTokensInPresentation) {
+        return {
+          result: false,
+          status: 403,
+          code: errorCode(2),
+          detailedError: `The number of VCs ${vc.length} in presentation exceeds the maximum ${validatorSafeguards.maxNumberOfVCTokensInPresentation}.`
+        }
+      }
 
+      let oversized = vc.filter((claimToken: ClaimToken) => typeof claimToken.rawToken === 'string' && claimToken.rawToken.length > validatorSafeguards.maxSizeOfVCTokensInPresentation);
+      if (oversized.length !== 0) {
+        return {
+          result: false,
+          status: 403,
+          code: errorCode(3),
+          detailedError: `The presentation has an oversized VC tokens. Size ${(<string>oversized[0].rawToken).length}. Maximum size: ${validatorSafeguards.maxSizeOfVCTokensInPresentation}.`
+        }
+      }
+
+      for (let token in vc) {
+        const claimToken = ClaimToken.create(vc[token]);
+        const vcType = VerifiableCredentialValidation.getVerifiableCredentialType(claimToken.decodedToken.vc || claimToken.decodedToken);
+        validationResponse.tokensToValidate[vcType] = claimToken;
+        queue.enqueueToken(vcType, claimToken);
+      }
+    }
+    
     return validationResponse;
   }
 

--- a/lib/api_validation/VerifiablePresentationTokenValidator.ts
+++ b/lib/api_validation/VerifiablePresentationTokenValidator.ts
@@ -60,7 +60,7 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
       };
     }
 
-    // Validation gate: Test for maximum number of tokens and maximum size
+    // Validation gate: Test for maximum number of VCs and maximum size
     const vc = validationResponse.payloadObject.vp.verifiableCredential;
     validationResponse.tokensToValidate = {};
     for (let token in vc) {

--- a/lib/api_validation/VerifiablePresentationTokenValidator.ts
+++ b/lib/api_validation/VerifiablePresentationTokenValidator.ts
@@ -60,6 +60,7 @@ export default class VerifiablePresentationTokenValidator implements ITokenValid
       };
     }
 
+    // Validation gate: Test for maximum number of tokens and maximum size
     const vc = validationResponse.payloadObject.vp.verifiableCredential;
     validationResponse.tokensToValidate = {};
     for (let token in vc) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,7 +31,8 @@ import IValidationResult from './api_validation/IValidationResult';
 import ValidatorBuilder from './api_validation/ValidatorBuilder';
 import SelfIssuedTokenValidator from './api_validation/SelfIssuedTokenValidator';
 import SiopTokenValidator from './api_validation/SiopTokenValidator';
-export { IValidationResult, SelfIssuedTokenValidator, SiopTokenValidator, VerifiablePresentationTokenValidator, VerifiableCredentialTokenValidator, IdTokenTokenValidator, Validator, ValidatorBuilder, ITokenValidator };
+import ValidationSafeguards from "./api_validation/ValidationSafeguards";
+export { ValidationSafeguards, IValidationResult, SelfIssuedTokenValidator, SiopTokenValidator, VerifiablePresentationTokenValidator, VerifiableCredentialTokenValidator, IdTokenTokenValidator, Validator, ValidatorBuilder, ITokenValidator };
 
 import { IValidationOptions } from './options/IValidationOptions';
 import IValidatorOptions from './options/IValidatorOptions';

--- a/lib/options/BasicValidatorOptions.ts
+++ b/lib/options/BasicValidatorOptions.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Crypto, IDidResolver, CryptoBuilder, IFetchRequest, FetchRequest } from '../index';
+import { Crypto, IDidResolver, CryptoBuilder, IFetchRequest, FetchRequest, ValidationSafeguards } from '../index';
 import IValidatorOptions from './IValidatorOptions';
 
 /**
@@ -12,19 +12,28 @@ export default class BasicValidatorOptions implements IValidatorOptions {
 
   private readonly _crypto: Crypto;
   private readonly _fetchRequest: IFetchRequest;
+  private readonly _validationSafeguards: ValidationSafeguards;
 
   constructor(private _resolver?: IDidResolver) {
     this._crypto = new CryptoBuilder().build();
     this._fetchRequest = new FetchRequest();
+    this._validationSafeguards = new ValidationSafeguards();
   }
 
   get resolver(): IDidResolver {
     return this._resolver!;
   }
 
-    /**
-     * The fetch client
-     */
+  /**
+   * The fetch client
+   */
+  get validationSafeguards(): ValidationSafeguards {
+    return this._validationSafeguards;
+  }
+
+  /**
+   * The fetch client
+   */
   get fetchRequest(): IFetchRequest {
     return this._fetchRequest;
   }

--- a/lib/options/IValidatorOptions.ts
+++ b/lib/options/IValidatorOptions.ts
@@ -11,6 +11,9 @@ import IFetchRequest from '../tracing/IFetchRequest';
  */
 export default interface IValidatorOptions {
 
+    // extend with validation gate
+
+    
     /**
      * The DID resolver
      */

--- a/lib/options/IValidatorOptions.ts
+++ b/lib/options/IValidatorOptions.ts
@@ -3,16 +3,13 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IDidResolver, Crypto } from '../index';
+import { IDidResolver, Crypto, ValidationSafeguards } from '../index';
 import IFetchRequest from '../tracing/IFetchRequest';
 
  /**
  * Interface to model the validator options
  */
 export default interface IValidatorOptions {
-
-    // extend with validation gate
-
     
     /**
      * The DID resolver
@@ -23,6 +20,11 @@ export default interface IValidatorOptions {
      * The fetch client
      */
     fetchRequest: IFetchRequest,
+
+    /**
+     * The validation safeguards
+     */
+    validationSafeguards: ValidationSafeguards,
 
     /**
      * Get the crypto options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.2",
+  "version": "0.12.1-preview.3",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/TestSetup.ts
+++ b/tests/TestSetup.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IssuanceHelpers } from './IssuanceHelpers';
-import { ManagedHttpResolver, CryptoBuilder, IKeyStore, SubtleCryptoNode, KeyReference } from '../lib/index';
+import { ManagedHttpResolver, CryptoBuilder, IKeyStore, SubtleCryptoNode, KeyReference, ValidationSafeguards } from '../lib/index';
 import IValidatorOptions from '../lib/options/IValidatorOptions';
 import FetchRequest from '../lib/tracing/FetchRequest';
 
@@ -100,6 +100,7 @@ export default class TestSetup {
   */
   public validatorOptions: IValidatorOptions = {
     fetchRequest: new FetchRequest(),
+    validationSafeguards: new ValidationSafeguards(),
     resolver: this.resolver,
     crypto: this.crypto
   };

--- a/tests/ValidationSafeguards.spec.ts
+++ b/tests/ValidationSafeguards.spec.ts
@@ -1,0 +1,44 @@
+import { ValidationSafeguards } from "../lib";
+
+
+describe('ValidationSafeguards', () => {
+  it('should instantiate', () => {
+    let safeguards = new ValidationSafeguards();
+    expect(safeguards.maxNumberOfIdTokensInSiop).toEqual(5);
+    expect(safeguards.maxNumberOfVCTokensInPresentation).toEqual(1);
+    expect(safeguards.maxNumberOfVPTokensInSiop).toEqual(10);
+    expect(safeguards.maxSizeOfIdToken).toEqual(16*1024*1024);
+    expect(safeguards.maxSizeOfVCTokensInPresentation).toEqual(16*1024*1024);
+    expect(safeguards.maxSizeOfVPTokensInSiop).toEqual(16*1024*1024);
+
+    // set individual props
+    safeguards = new ValidationSafeguards({maxNumberOfIdTokensInSiop: 10});
+    expect(safeguards.maxNumberOfIdTokensInSiop).toEqual(10);
+    safeguards = new ValidationSafeguards({maxNumberOfVCTokensInPresentation: 20});
+    expect(safeguards.maxNumberOfVCTokensInPresentation).toEqual(20);
+    safeguards = new ValidationSafeguards({maxNumberOfVPTokensInSiop: 30});
+    expect(safeguards.maxNumberOfVPTokensInSiop).toEqual(30);
+    safeguards = new ValidationSafeguards({maxSizeOfIdToken: 1000});
+    expect(safeguards.maxSizeOfIdToken).toEqual(1000);
+    safeguards = new ValidationSafeguards({maxSizeOfVCTokensInPresentation: 2000});
+    expect(safeguards.maxSizeOfVCTokensInPresentation).toEqual(2000);
+    safeguards = new ValidationSafeguards({maxSizeOfVPTokensInSiop: 3000});
+    expect(safeguards.maxSizeOfVPTokensInSiop).toEqual(3000);
+  });
+
+  it('should modify state', () => {
+    let safeguards = new ValidationSafeguards();
+    safeguards.maxNumberOfIdTokensInSiop = 20;
+    expect(safeguards.maxNumberOfIdTokensInSiop).toEqual(20);
+    safeguards.maxNumberOfVCTokensInPresentation = 25;
+    expect(safeguards.maxNumberOfVCTokensInPresentation).toEqual(25);
+    safeguards.maxNumberOfVPTokensInSiop = 30;
+    expect(safeguards.maxNumberOfVPTokensInSiop).toEqual(30);
+    safeguards.maxSizeOfIdToken = 40;
+    expect(safeguards.maxSizeOfIdToken).toEqual(40);
+    safeguards.maxSizeOfVCTokensInPresentation = 50;
+    expect(safeguards.maxSizeOfVCTokensInPresentation).toEqual(50);
+    safeguards.maxSizeOfVPTokensInSiop = 60;
+    expect(safeguards.maxSizeOfVPTokensInSiop).toEqual(60);
+  });
+});

--- a/tests/ValidatorBuilder.spec.ts
+++ b/tests/ValidatorBuilder.spec.ts
@@ -73,4 +73,22 @@ describe('ValidatorBuilder', () => {
     expect(builder.nonce).toEqual('12345');
   });
 
+  it('should modify validation safeguards', () => {
+    const crypto = new CryptoBuilder().build();
+    let builder = new ValidatorBuilder(crypto);
+
+    //builder.useMaxNumberOfIdTokensInSiop = 20;
+    //expect(safeguards.maxNumberOfIdTokensInSiop).toEqual(20);
+    builder.useMaxNumberOfVCTokensInPresentation = 25;
+    expect(builder.maxNumberOfVCTokensInPresentation).toEqual(25);
+    //builder.useMaxNumberOfVPTokensInSiop = 30;
+    //expect(builder.maxNumberOfVPTokensInSiop).toEqual(30);
+    builder.useMaxSizeOfIdToken = 40;
+    expect(builder.maxSizeOfIdToken).toEqual(40);
+    builder.useMaxSizeOfVCTokensInPresentation = 50;
+    expect(builder.maxSizeOfVCTokensInPresentation).toEqual(50);
+    builder.useMaxSizeOfVPTokensInSiop = 60;
+    expect(builder.maxSizeOfVPTokensInSiop).toEqual(60);
+  });
+
 });

--- a/tests/ValidatorBuilder.spec.ts
+++ b/tests/ValidatorBuilder.spec.ts
@@ -21,6 +21,7 @@ describe('ValidatorBuilder', () => {
     const options = new BasicValidatorOptions();
     let builder = new ValidatorBuilder(options.crypto)
       .useFetchRequest(fetchRequest)
+      .useMaxSizeOfVPTokensInSiop(options.validationSafeguards.maxSizeOfVPTokensInSiop)
       .useResolver(resolver);
     expect(builder.crypto).toEqual(builder.validationOptions.crypto);
     expect(builder.fetchRequest).toEqual(builder.validationOptions.fetchRequest);
@@ -79,15 +80,15 @@ describe('ValidatorBuilder', () => {
 
     //builder.useMaxNumberOfIdTokensInSiop = 20;
     //expect(safeguards.maxNumberOfIdTokensInSiop).toEqual(20);
-    builder.useMaxNumberOfVCTokensInPresentation = 25;
+    builder.useMaxNumberOfVCTokensInPresentation(25);
     expect(builder.maxNumberOfVCTokensInPresentation).toEqual(25);
     //builder.useMaxNumberOfVPTokensInSiop = 30;
     //expect(builder.maxNumberOfVPTokensInSiop).toEqual(30);
-    builder.useMaxSizeOfIdToken = 40;
+    builder.useMaxSizeOfIdToken(40);
     expect(builder.maxSizeOfIdToken).toEqual(40);
-    builder.useMaxSizeOfVCTokensInPresentation = 50;
+    builder.useMaxSizeOfVCTokensInPresentation(50);
     expect(builder.maxSizeOfVCTokensInPresentation).toEqual(50);
-    builder.useMaxSizeOfVPTokensInSiop = 60;
+    builder.useMaxSizeOfVPTokensInSiop(60);
     expect(builder.maxSizeOfVPTokensInSiop).toEqual(60);
   });
 

--- a/tests/models/RequestTwoVcResponseOk.ts
+++ b/tests/models/RequestTwoVcResponseOk.ts
@@ -7,176 +7,176 @@ import { ClaimToken, TokenType } from "../../lib";
 
 
 export default class RequestTwoVcResponseOk implements ITestModel {
-    public clientId = 'https://requestor.example.com';
+  public clientId = 'https://requestor.example.com';
 
-    /**
-     * Define the model for the request
-     */
-    public request: any = {
-        clientId: this.clientId,
-        clientName: 'My relying party',
-        clientPurpose: 'Need your VC to provide access',
-        redirectUri: this.clientId,
-        tosUri: 'https://tosUri.example.com',
-        logoUri: 'https://logoUri.example.com',
+  /**
+   * Define the model for the request
+   */
+  public request: any = {
+    clientId: this.clientId,
+    clientName: 'My relying party',
+    clientPurpose: 'Need your VC to provide access',
+    redirectUri: this.clientId,
+    tosUri: 'https://tosUri.example.com',
+    logoUri: 'https://logoUri.example.com',
 
-        presentationDefinition: {
-            name: 'Get identity card',
-            purpose: 'Needed to provide you access to the site',
-            input_descriptors: [
-                {
-                    id: 'IdentityCard',
-                    schema: {
-                        uri: ['https://schema.org/IdentityCardCredential'],
-                        name: 'IdentityCard',
-                        purpose: 'Testing the site'
-                    },
-                    issuance: [
-                        {
-                            manifest: 'https://portableidentitycards.azure-api.net/dev-v1.0/536279f6-15cc-45f2-be2d-61e352b51eef/portableIdentities/contracts/IdentityCard1'
-                        }
-                    ]
-                },
-                {
-                    id: 'Diploma',
-                    schema: {
-                        uri: ['https://schema.org/Diploma'],
-                        name: 'Diploma',
-                        purpose: 'Proving diploma'
-                    },
-                    issuance: [
-                        {
-                            manifest: 'https://portableidentitycards.azure-api.net/dev-v1.0/536279f6-15cc-45f2-be2d-61e352b51eef/portableIdentities/contracts/Diploma'
-                        }
-                    ]
-                }
-            ]
-        }
-    }
-
-
-    /**
-     * Define the model for the response
-     */
-    public response: any = {
-        iss: 'https://self-issued.me',
-        aud: this.clientId,
-        nonce: '',
-        state: '',
-        did: '',
-        jti: 'fa8fdc8f-d95b-4237-9c90-9696112f4e19',
-        presentation_submission: {
-            descriptor_map: [
-                {
-                    id: 'IdentityCard',
-                    format: 'jwt',
-                    encoding: 'base64Url',
-                    path: '$.presentation_submission.attestations.presentations.IdentityCard'
-                },
-                {
-                    id: 'Diploma',
-                    format: 'jwt',
-                    encoding: 'base64Url',
-                    path: '$.presentation_submission.attestations.presentations.Diploma'
-                }
-             ],
-        attestations: {
-                presentations: {
-                    IdentityCard: {
-                        'jti': `urn:pic:IdentityCard`,
-                        'vc': {
-                            '\@context': [
-                                'https://www.w3.org/2018/credentials/v1',
-                                'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/contracts/test/schema'
-                            ],
-                            'type': [
-                                'VerifiableCredential',
-                                'IdentityCard'
-                            ],
-                            'credentialSubject': {
-                                givenName: 'Jules',
-                                familyName: 'Winnfield',
-                                profession: 'hitman'
-                            },
-                            'credentialStatus': {
-                                'id': `https://status.example.com/IdentityCard`,
-                                'type': 'PortableIdentityCardServiceCredentialStatus2020'
-                            }
-                        },
-                    },
-                    Diploma: {
-                        'jti': `urn:pic:Diploma`,
-                        'vc': {
-                            '\@context': [
-                                'https://www.w3.org/2018/credentials/v1',
-                                'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/contracts/test/Diploma'
-                            ],
-                            'type': [
-                                'VerifiableCredential',
-                                'Diploma'
-                            ],
-                            'credentialSubject': {
-                                level: 'master',
-                                university: 'rentakill'
-                            },
-                            'credentialStatus': {
-                                'id': `https://status.example.com/Diploma`,
-                                'type': 'PortableIdentityCardServiceCredentialStatus2020'
-                            }
-                        },
-                    },
-
-                },
+    presentationDefinition: {
+      name: 'Get identity card',
+      purpose: 'Needed to provide you access to the site',
+      input_descriptors: [
+        {
+          id: 'IdentityCard',
+          schema: {
+            uri: ['https://schema.org/IdentityCardCredential'],
+            name: 'IdentityCard',
+            purpose: 'Testing the site'
+          },
+          issuance: [
+            {
+              manifest: 'https://portableidentitycards.azure-api.net/dev-v1.0/536279f6-15cc-45f2-be2d-61e352b51eef/portableIdentities/contracts/IdentityCard1'
             }
-        }
-    }
-
-    public responseStatus = {
-        'IdentityCard': {
-            'credentialStatus': {
-                'status': 'valid',
-                'reason': `Totally checked`
-            }
+          ]
         },
-        'Diploma': {
-            'credentialStatus': {
-                'status': 'valid',
-                'reason': `Accredited`
+        {
+          id: 'Diploma',
+          schema: {
+            uri: ['https://schema.org/Diploma'],
+            name: 'Diploma',
+            purpose: 'Proving diploma'
+          },
+          issuance: [
+            {
+              manifest: 'https://portableidentitycards.azure-api.net/dev-v1.0/536279f6-15cc-45f2-be2d-61e352b51eef/portableIdentities/contracts/Diploma'
             }
+          ]
         }
-    };
-
-    /**
-     * Return a specific VC
-     * @param key Name for the vc
-     */
-    public getVcFromResponse(key: string): ClaimToken {
-        // Decode de presentation
-        let claimToken = ClaimToken.create(this.response.presentation_submission.attestations.presentations[key]);
-
-        claimToken =  ClaimToken.create(claimToken.decodedToken.vp.verifiableCredential[0]);
-        return claimToken;
+      ]
     }
+  }
 
 
-    /**
-     * Return all presentations
-     */
-    public getPresentationsFromModel(): { [key: string]: any } {
-        return this.response.presentation_submission.attestations.presentations;
-    }
+  /**
+   * Define the model for the response
+   */
+  public response: any = {
+    iss: 'https://self-issued.me',
+    aud: this.clientId,
+    nonce: '',
+    state: '',
+    did: '',
+    jti: 'fa8fdc8f-d95b-4237-9c90-9696112f4e19',
+    presentation_submission: {
+      descriptor_map: [
+        {
+          id: 'IdentityCard',
+          format: 'jwt',
+          encoding: 'base64Url',
+          path: '$.presentation_submission.attestations.presentations.IdentityCard'
+        },
+        {
+          id: 'Diploma',
+          format: 'jwt',
+          encoding: 'base64Url',
+          path: '$.presentation_submission.attestations.presentations.Diploma'
+        }
+      ],
+      attestations: {
+        presentations: {
+          IdentityCard: {
+            'jti': `urn:pic:IdentityCard`,
+            'vc': {
+              '\@context': [
+                'https://www.w3.org/2018/credentials/v1',
+                'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/contracts/test/schema'
+              ],
+              'type': [
+                'VerifiableCredential',
+                'IdentityCard'
+              ],
+              'credentialSubject': {
+                givenName: 'Jules',
+                familyName: 'Winnfield',
+                profession: 'hitman'
+              },
+              'credentialStatus': {
+                'id': `https://status.example.com/IdentityCard`,
+                'type': 'PortableIdentityCardServiceCredentialStatus2020'
+              }
+            },
+          },
+          Diploma: {
+            'jti': `urn:pic:Diploma`,
+            'vc': {
+              '\@context': [
+                'https://www.w3.org/2018/credentials/v1',
+                'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/contracts/test/Diploma'
+              ],
+              'type': [
+                'VerifiableCredential',
+                'Diploma'
+              ],
+              'credentialSubject': {
+                level: 'master',
+                university: 'rentakill'
+              },
+              'credentialStatus': {
+                'id': `https://status.example.com/Diploma`,
+                'type': 'PortableIdentityCardServiceCredentialStatus2020'
+              }
+            },
+          },
 
-    /**
-     * Return all non presented VCs
-     */
-    public getNonPresentedVcFromModel(): { [key: string]: any } {
-        return {};
+        },
+      }
     }
-    
-    /**
-     * Return all id tokens from model
-     */
-    public getIdTokensFromModel(): { [key: string]: any } {
-        return {};
+  }
+
+  public responseStatus = {
+    'IdentityCard': {
+      'credentialStatus': {
+        'status': 'valid',
+        'reason': `Totally checked`
+      }
+    },
+    'Diploma': {
+      'credentialStatus': {
+        'status': 'valid',
+        'reason': `Accredited`
+      }
     }
+  };
+
+  /**
+   * Return a specific VC
+   * @param key Name for the vc
+   */
+  public getVcFromResponse(key: string): ClaimToken {
+    // Decode de presentation
+    let claimToken = ClaimToken.create(this.response.presentation_submission.attestations.presentations[key]);
+
+    claimToken = ClaimToken.create(claimToken.decodedToken.vp.verifiableCredential[0]);
+    return claimToken;
+  }
+
+
+  /**
+   * Return all presentations
+   */
+  public getPresentationsFromModel(): { [key: string]: any } {
+    return this.response.presentation_submission.attestations.presentations;
+  }
+
+  /**
+   * Return all non presented VCs
+   */
+  public getNonPresentedVcFromModel(): { [key: string]: any } {
+    return {};
+  }
+
+  /**
+   * Return all id tokens from model
+   */
+  public getIdTokensFromModel(): { [key: string]: any } {
+    return {};
+  }
 }


### PR DESCRIPTION
**Problem:**
An app can send many times the same VC in a VP in order to do a DOS attack.


**Solution:**
Added validation safeguards which limits the number of tokens that can be in a SIOP and the size of the token.

**Validation:**
Added new unit tests

**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

