### PR TITLE
Performance enhancements

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,9 @@
+# version 0.12.1-preview.7
+## Performance improvements for ClaimToken.Create
+**Type of change:** feature work
+**Customer impact:** low
+- Don't parse a jwt multiple times
+
 # version 0.12.1-preview.6
 ## Attack vector protection IdToken Hint
 **Type of change:** feature work

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,14 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
- 
+
 export { DidDocument, IDidDocument, IDidDocumentPublicKey, IDidDocumentServiceDescriptor, IDidResolver, IDidResolveResult } from '@decentralized-identity/did-common-typescript';
 
 import FetchRequest from './tracing/FetchRequest';
 import IFetchRequest from './tracing/IFetchRequest';
 export { FetchRequest, IFetchRequest };
 
-import {IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSelfIssued, IExpectedIdToken, IExpectedOpenIdToken, IExpectedAudience, IssuerMap} from './options/IExpected';
+import { IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSelfIssued, IExpectedIdToken, IExpectedOpenIdToken, IExpectedAudience, IssuerMap } from './options/IExpected';
 export { IExpectedStatusReceipt, IExpectedBase, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpectedSelfIssued, IExpectedIdToken, IExpectedOpenIdToken, IExpectedAudience, IssuerMap };
 
 import { RulesValidationError } from './error_handling/RulesValidationError';
@@ -56,7 +56,7 @@ import { VerifiablePresentationValidation } from './input_validation/VerifiableP
 import { DidValidation } from './input_validation/DidValidation'
 import { SiopValidation } from './input_validation/SiopValidation'
 import { VerifiableCredentialValidation } from './input_validation/VerifiableCredentialValidation';
-import VerifiablePresentationStatusReceipt, { IVerifiablePresentationStatus }  from './api_validation/VerifiablePresentationStatusReceipt';
+import VerifiablePresentationStatusReceipt, { IVerifiablePresentationStatus } from './api_validation/VerifiablePresentationStatusReceipt';
 export { VerifiablePresentationStatusReceipt, IVerifiablePresentationStatus, IValidationResponse, IdTokenValidationResponse, ISiopValidationResponse, IdTokenValidation, VerifiablePresentationValidation, DidValidation, SiopValidation, VerifiableCredentialValidation, BaseIdTokenValidation, OpenIdTokenValidation };
 
 import IRevocedCard from './revocation/IRevokedCard';
@@ -92,12 +92,12 @@ import { TrustedIssuerModel } from './rules_model/TrustedIssuerModel';
 import { VerifiablePresentationAttestationModel } from './rules_model/VerifiablePresentationAttestationModel';
 import { RefreshConfigurationModel } from './rules_model/RefreshConfigurationModel';
 import { VerifiableCredentialModel } from './rules_model/VerifiableCredentialModel';
-import { TransformModel } from './rules_model/TransformModel'; 
-import { PresentationDefinitionModel } from './rules_model/presentation_exchange/PresentationDefinitionModel'; 
-import { PresentationExchangeInputDescriptorModel } from './rules_model/presentation_exchange/PresentationExchangeInputDescriptorModel'; 
-import { PresentationExchangeSchemaModel } from './rules_model/presentation_exchange/PresentationExchangeSchemaModel'; 
-import { PresentationExchangeIssuanceModel } from './rules_model/presentation_exchange/PresentationExchangeIssuanceModel'; 
-import { PresentationExchangeConstraintsModel } from './rules_model/presentation_exchange/PresentationExchangeConstraintsModel'; 
+import { TransformModel } from './rules_model/TransformModel';
+import { PresentationDefinitionModel } from './rules_model/presentation_exchange/PresentationDefinitionModel';
+import { PresentationExchangeInputDescriptorModel } from './rules_model/presentation_exchange/PresentationExchangeInputDescriptorModel';
+import { PresentationExchangeSchemaModel } from './rules_model/presentation_exchange/PresentationExchangeSchemaModel';
+import { PresentationExchangeIssuanceModel } from './rules_model/presentation_exchange/PresentationExchangeIssuanceModel';
+import { PresentationExchangeConstraintsModel } from './rules_model/presentation_exchange/PresentationExchangeConstraintsModel';
 export {
   AuthenticationModel,
   AuthenticationScheme,
@@ -125,4 +125,10 @@ export {
   SelfIssuedAttestationModel,
   TrustedIssuerModel,
   VerifiablePresentationAttestationModel
+};
+
+import JsonWebSignatureToken, { TokenPayload } from './verifiable_credential/JsonWebSignatureToken';
+export {
+  JsonWebSignatureToken,
+  TokenPayload,
 };

--- a/lib/verifiable_credential/ClaimToken.ts
+++ b/lib/verifiable_credential/ClaimToken.ts
@@ -77,13 +77,6 @@ export default class ClaimToken {
   private readonly _jsonWebToken?: JsonWebSignatureToken;
 
   /**
-   * JsonWebSignatureToken instance 
-   */
-  public get jsonWebToken(): JsonWebSignatureToken | undefined {
-    return this._jsonWebToken;
-  }
-
-  /**
    * Token type
    */
   public get type(): TokenType {

--- a/lib/verifiable_credential/JsonWebSignatureToken.ts
+++ b/lib/verifiable_credential/JsonWebSignatureToken.ts
@@ -5,7 +5,7 @@
 import base64url from 'base64url';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
 import ValidationError from '../error_handling/ValidationError';
-const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKJWTO', error);
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKJWST', error);
 
 /**
  * Type that describes an object that maps a key to a value.

--- a/lib/verifiable_credential/JsonWebSignatureToken.ts
+++ b/lib/verifiable_credential/JsonWebSignatureToken.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import base64url from 'base64url';
+import ErrorHelpers from '../error_handling/ErrorHelpers';
+import ValidationError from '../error_handling/ValidationError';
+const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKJWTO', error);
+
+/**
+ * Type that describes an object that maps a key to a value.
+ */
+export type TokenPayload = { [claim: string]: any };
+
+/**
+ * class for parsing unecrypted Json Web Tokens
+ */
+export default class JsonWebSignatureToken {
+  /**
+   * The expected number of parts for a JWS compact token
+   */
+  private static readonly EXPECTED_PARTS: number = 3;
+
+  /**
+   * Encoding of the header as mandated per JWS rfc: https://tools.ietf.org/html/rfc7515#section-2
+   */
+  private static readonly UTF8_ENCODING = 'utf8';
+
+  /**
+   * flag indicating whether or not the token is an unsecured jws
+   */
+  public readonly unsecured: boolean;
+
+  /**
+   * Decoded header of the token
+   */
+  public readonly header: TokenPayload;
+
+  /**
+   * decoded payload of the token
+   */
+  public readonly payload: TokenPayload;
+
+  /**
+   * encoded signature of the token
+   */
+  public readonly signature: string;
+
+  /**
+   * the length of the pre-image of the token
+   * per RFC7515: https://tools.ietf.org/html/rfc7515#section-3.3
+   */
+  private readonly preimageLength: number;
+
+  /**
+   * Create a parsed JsonWebSignatureToken per https://tools.ietf.org/html/rfc7515#section-7.1
+   * @param token jws compact token string
+   */
+  constructor(public readonly token: string) {
+    const parts = token.split('.');
+
+    // a signed jws is header.payload.signature per https://tools.ietf.org/html/rfc7515#section-7.1
+    // a unsecured jws is header.payload. per https://tools.ietf.org/html/rfc7515#appendix-A.5
+    if (parts.length < JsonWebSignatureToken.EXPECTED_PARTS) {
+      throw new ValidationError('Invalid json web token', errorCode(1));
+    }
+
+    this.header = JsonWebSignatureToken.parsePayload(parts[0], 'header', 2);
+    this.payload = JsonWebSignatureToken.parsePayload(parts[1], 'payload', 3);
+    this.signature = parts[2];
+    this.unsecured = !parts[2];
+
+    // the preimage does not include a the trailing seperator
+    this.preimageLength = 1 + parts[0].length + parts[1].length;
+  }
+
+  /**
+   * Encode a protected header and payload into a unsecured compact jws
+   * @param header TokenPayload instance
+   * @param payload TokenPayload instance
+   * @returns JsonWebSignatureToken instance
+   */
+  public static encode(header: TokenPayload, payload: TokenPayload): JsonWebSignatureToken {
+    const encodedHeader = base64url.encode(JSON.stringify(header), JsonWebSignatureToken.UTF8_ENCODING);
+    const encodedPayload = base64url.encode(JSON.stringify(payload), JsonWebSignatureToken.UTF8_ENCODING);
+    return new JsonWebSignatureToken(`${encodedHeader}.${encodedPayload}.`);
+  }
+
+  /**
+   * parse a payload
+   * @param encodedPart encoded string
+   * @param name name of the part
+   * @param scenario scenario id
+   * @returns TokenPayload instance
+   */
+  private static parsePayload(encodedPart: string, name: string, scenario: number): TokenPayload {
+    try {
+      return JSON.parse(base64url.decode(encodedPart));
+    } catch (error) {
+      throw new ValidationError(`Invalid json web token the ${name} is malformed`, errorCode(scenario));
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.6",
+  "version": "0.12.1-preview.7",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/IssuanceHelpers.ts
+++ b/tests/IssuanceHelpers.ts
@@ -6,9 +6,8 @@ import { JoseBuilder, Subtle } from 'verifiablecredentials-crypto-sdk-typescript
 import TestSetup from './TestSetup';
 import { DidDocument } from '@decentralized-identity/did-common-typescript';
 import ClaimToken, { TokenType } from '../lib/verifiable_credential/ClaimToken';
-import base64url from "base64url";
 import ValidationOptions from '../lib/options/ValidationOptions';
-import { KeyReference, IExpectedBase, IExpectedSelfIssued, IExpectedIdToken, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, Validator } from '../lib/index';
+import { KeyReference, IExpectedBase, IExpectedSelfIssued, IExpectedIdToken, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, JsonWebSignatureToken, TokenPayload } from '../lib/index';
 
 export class IssuanceHelpers {
   public static readonly jti: string = 'testJti';
@@ -41,20 +40,21 @@ export class IssuanceHelpers {
    * Create a verifiable credentiaL
    * @param claims Credential claims
    */
-  public static createSelfIssuedToken(claims: { [claim: string]: string }): ClaimToken {
-    const header = base64url.encode(JSON.stringify({
+  public static createSelfIssuedToken(claims: TokenPayload): ClaimToken {
+    const header = {
       alg: "none",
       typ: 'JWT'
-    }));
-    const body = base64url.encode(JSON.stringify(claims));
-    return new ClaimToken(TokenType.selfIssued, `${header}.${body}`, '');
+    };
+
+    const jwt = JsonWebSignatureToken.encode(header, claims);
+    return new ClaimToken(TokenType.selfIssued, jwt, '');
   }
 
   /**
    * Create a verifiable credential
    * @param claims Token claims
    */
-  public static async createVc(setup: TestSetup, credentialSubject: { [claim: string]: any }, configuration: string, jwkPrivate: any, jwkPublic: any): Promise<ClaimToken> {
+  public static async createVc(setup: TestSetup, credentialSubject: TokenPayload, configuration: string, jwkPrivate: any, jwkPublic: any): Promise<ClaimToken> {
     // Set the mock because we will resolve the signing key as did
     await this.resolverMock(setup, setup.defaultIssuerDid, jwkPrivate, jwkPublic);
     const statusUrl = 'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/status';

--- a/tests/JsonWebSignatureToken.spec.ts
+++ b/tests/JsonWebSignatureToken.spec.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import base64url from 'base64url';
+import { JsonWebSignatureToken, TokenPayload, ValidationError } from '../lib';
+
+describe('JsonWebSignatureToken', () => {
+  let knownJwt: string;
+  let knownUnsecuredJwt: string;
+  let header: TokenPayload;
+  let payload: TokenPayload;
+  let signature: string;
+
+  beforeAll(() => {
+    // test vector as defined in rfc https://tools.ietf.org/html/rfc7519#section-3.1
+    knownJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    knownUnsecuredJwt = knownJwt.substring(0, knownJwt.lastIndexOf('.') + 1);
+    signature = knownJwt.substring(knownJwt.lastIndexOf('.') + 1);
+    header = {
+      typ: "JWT",
+      alg: 'HS256',
+    };
+
+    payload = {
+      iss: 'joe',
+      exp: 1300819380,
+      ['http://example.com/is_root']: true,
+    };
+  });
+
+  describe('encode', () => {
+    it('must encode input as jwt', () => {
+      const token = JsonWebSignatureToken.encode(header, payload);
+      expect(token.token).toEqual(knownUnsecuredJwt);
+    });
+  });
+
+  describe('ctor', () => {
+    it('must handle test vector', () => {
+      const token = new JsonWebSignatureToken(knownJwt);
+      expect(token.unsecured).toBeFalsy();
+      expect(token.signature).toEqual(signature);
+      expect(token.header).toEqual(header);
+      expect(token.payload).toEqual(payload);
+      expect(token['preimageLength']).toEqual(knownUnsecuredJwt.length - 1);
+    });
+
+    it('must handle unsecured jwt', () => {
+      const token = new JsonWebSignatureToken(knownUnsecuredJwt);
+      expect(token.unsecured).toEqual(true);
+      expect(token.signature).toBeFalsy();
+      expect(token.header).toEqual(header);
+      expect(token.payload).toEqual(payload);
+      expect(token['preimageLength']).toEqual(knownUnsecuredJwt.length - 1);
+    });
+
+    it('must reject unsecured jwt without trailing seperator', () => {
+      try {
+        new JsonWebSignatureToken(knownUnsecuredJwt.substring(0, knownUnsecuredJwt.length - 1));
+        fail('error expected');
+      } catch (error) {
+        expect(error instanceof ValidationError).toBeTruthy();
+      }
+    });
+
+    it('must reject malformed jwt without seperator', () => {
+      try {
+        new JsonWebSignatureToken('not a real token');
+        fail('error expected');
+      } catch (error) {
+        expect(error instanceof ValidationError).toBeTruthy();
+      }
+    });
+
+    it('must reject malformed header', () => {
+      try {
+        // this is not valid base64
+        new JsonWebSignatureToken(`bad.${base64url.encode(JSON.stringify(payload))}.`);
+        fail('error expected');
+      } catch (error) {
+        expect(error instanceof ValidationError).toBeTruthy();
+      }
+    });
+
+    it('must reject malformed payload', () => {
+      try {
+        // not a valid json object
+        new JsonWebSignatureToken(`${base64url.encode(JSON.stringify(header))}.aqab.`);
+        fail('error expected');
+      } catch (error) {
+        expect(error instanceof ValidationError).toBeTruthy();
+      }
+    });
+  });
+});

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -1,4 +1,4 @@
-import { TokenType, ValidatorBuilder, IdTokenTokenValidator, VerifiableCredentialTokenValidator, VerifiablePresentationTokenValidator, IExpectedVerifiableCredential, IExpectedVerifiablePresentation, IExpectedIdToken, IExpectedSiop, IExpectedSelfIssued, Validator, CryptoBuilder, ManagedHttpResolver, ClaimToken } from '../lib/index';
+import { TokenType, ValidatorBuilder, IdTokenTokenValidator, VerifiableCredentialTokenValidator, VerifiablePresentationTokenValidator, IExpectedVerifiableCredential, IExpectedVerifiablePresentation, IExpectedIdToken, IExpectedSiop, IExpectedSelfIssued, Validator, CryptoBuilder, ManagedHttpResolver, ClaimToken, JsonWebSignatureToken } from '../lib/index';
 import { IssuanceHelpers } from './IssuanceHelpers';
 import TestSetup from './TestSetup';
 import ValidationQueue from '../lib/input_validation/ValidationQueue';
@@ -377,23 +377,19 @@ describe('Validator', () => {
 
   describe('setValidationResult()', () => {
     let validator: Validator;
-    let decodeSpy: jasmine.Spy<() => void>;
 
     beforeAll(() => {
       validator = new Validator(new ValidatorBuilder(new Crypto(new CryptoBuilder())));
-      decodeSpy = spyOn((<any>ClaimToken).prototype, 'decode');
-    });
-
-    beforeEach(() => {
-      decodeSpy.and.stub();
     });
 
     it('should add IdTokens and IdTokenHints to the same object', () => {
+      const dummyPayload = JsonWebSignatureToken.encode({}, {});
+
       // Set up queue.
       const queue = new ValidationQueue();
       const id = 'idToken';
-      const idTokenClaimToken = new ClaimToken(TokenType.idToken, 'someToken', id);
-      const idTokenHintClaimToken = new ClaimToken(TokenType.idTokenHint, 'someToken', VerifiableCredentialConstants.TOKEN_SI_ISS);
+      const idTokenClaimToken = new ClaimToken(TokenType.idToken, dummyPayload, id);
+      const idTokenHintClaimToken = new ClaimToken(TokenType.idTokenHint, dummyPayload, VerifiableCredentialConstants.TOKEN_SI_ISS);
       const idTokenItem = new ValidationQueueItem(id, idTokenClaimToken);
       const idTokenHintItem = new ValidationQueueItem(VerifiableCredentialConstants.TOKEN_SI_ISS, idTokenHintClaimToken);
       queue.enqueueItem(idTokenItem);


### PR DESCRIPTION
**Problem:**
ClaimToken.create had a path where a jwt was decoded multiple times.  For JSON LD it relied on string.split and an error to determine a known condition


**Solution:**
Refactor ClaimToken.create to decode a JWT once


**Validation:**
Existing unit tests work


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

