### PR TITLE
Self Issued Open Id Invalid Token Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ bld/
 .user
 /services/PouchDbClient/testdb
 package-lock.json
+/.npmrc

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,10 @@
+# version 0.12.1-preview.8
+## Performance improvements for ClaimToken.Create
+**Type of change:** feature work
+**Customer impact:** medium
+- Allow customizable status code for token validation errors
+- Default behavior is that invalid tokens result in 401
+
 # version 0.12.1-preview.7
 ## Performance improvements for ClaimToken.Create
 **Type of change:** feature work

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -12,7 +12,6 @@ import ValidationQueueItem from '../input_validation/ValidationQueueItem';
 import { SiopValidation } from '../input_validation/SiopValidation';
 import VerifiableCredentialConstants from '../verifiable_credential/VerifiableCredentialConstants';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
-import { AuthenticationError } from '@azure/identity';
 const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKSTVa', error);
 
 /**
@@ -137,7 +136,7 @@ export default class SiopTokenValidator implements ITokenValidator {
           status: this.validatorOption.invalidTokenError,
           detailedError: AuthenticationErrorDescription.malformedToken,
           code: errorCode(5),
-          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
     }
 

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -55,7 +55,6 @@ export default class SiopTokenValidator implements ITokenValidator {
           status: this.validatorOption.invalidTokenError,
           code: errorCode(1),
           detailedError: `Expected nonce '${this.expected.nonce}' does not match '${validationResponse.payloadObject.nonce}'.`,
-          realm: VerifiableCredentialConstants.TOKEN_SI_ISS,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         }
       }
@@ -67,7 +66,6 @@ export default class SiopTokenValidator implements ITokenValidator {
           status: this.validatorOption.invalidTokenError,
           code: errorCode(2),
           detailedError: `Expected state '${this.expected.state}' does not match '${validationResponse.payloadObject.state}'.`,
-          realm: VerifiableCredentialConstants.TOKEN_SI_ISS,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         }
       }
@@ -137,7 +135,6 @@ export default class SiopTokenValidator implements ITokenValidator {
           detailedError: AuthenticationErrorDescription.malformedToken,
           code: errorCode(5),
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
-          realm: VerifiableCredentialConstants.TOKEN_SI_ISS,
         };
     }
 

--- a/lib/api_validation/SiopTokenValidator.ts
+++ b/lib/api_validation/SiopTokenValidator.ts
@@ -137,6 +137,7 @@ export default class SiopTokenValidator implements ITokenValidator {
           detailedError: AuthenticationErrorDescription.malformedToken,
           code: errorCode(5),
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
+          realm: VerifiableCredentialConstants.TOKEN_SI_ISS,
         };
     }
 

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -161,16 +161,34 @@ export default class ValidatorBuilder {
         idToken: new IdTokenTokenValidator(validatorOptions, <IExpectedIdToken>{ type: TokenType.idToken, configuration: this._trustedIssuerConfigurationsForIdTokens }),
         verifiableCredential: new VerifiableCredentialTokenValidator(validatorOptions, <IExpectedVerifiableCredential>{ type: TokenType.verifiableCredential, contractIssuers: this._trustedIssuersForVerifiableCredentials }),
         verifiablePresentationJwt: new VerifiablePresentationTokenValidator(validatorOptions, <IExpectedVerifiablePresentation>{ type: TokenType.verifiablePresentationJwt, didAudience: this.crypto.builder.did }),
-        siopPresentationAttestation: new SiopTokenValidator(validatorOptions, <IExpectedSiop>{ type: TokenType.siopPresentationAttestation, audience: this._audienceUrl }),
-        siop: new SiopTokenValidator(
-          validatorOptions, 
-          { 
-            type: TokenType.siop, 
-            audience: this._audienceUrl, 
-            realm: VerifiableCredentialConstants.TOKEN_SI_ISS 
+        siopPresentationAttestation: new SiopTokenValidator(
+          validatorOptions,
+          {
+            type: TokenType.siopPresentationAttestation,
+            audience: this._audienceUrl,
+            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
           }),
-        siopPresentationExchange: new SiopTokenValidator(validatorOptions, <IExpectedSiop>{ type: TokenType.siopPresentationExchange, audience: this._audienceUrl }),
-        siopIssuance: new SiopTokenValidator(validatorOptions, <IExpectedSiop>{ type: TokenType.siopIssuance, audience: this._audienceUrl })
+        siop: new SiopTokenValidator(
+          validatorOptions,
+          {
+            type: TokenType.siop,
+            audience: this._audienceUrl,
+            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
+          }),
+        siopPresentationExchange: new SiopTokenValidator(
+          validatorOptions,
+          {
+            type: TokenType.siopPresentationExchange,
+            audience: this._audienceUrl,
+            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
+          }),
+        siopIssuance: new SiopTokenValidator(
+          validatorOptions,
+          {
+            type: TokenType.siopIssuance,
+            audience: this._audienceUrl,
+            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
+          })
       };
     }
 

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -166,28 +166,24 @@ export default class ValidatorBuilder {
           {
             type: TokenType.siopPresentationAttestation,
             audience: this._audienceUrl,
-            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
           }),
         siop: new SiopTokenValidator(
           validatorOptions,
           {
             type: TokenType.siop,
             audience: this._audienceUrl,
-            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
           }),
         siopPresentationExchange: new SiopTokenValidator(
           validatorOptions,
           {
             type: TokenType.siopPresentationExchange,
             audience: this._audienceUrl,
-            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
           }),
         siopIssuance: new SiopTokenValidator(
           validatorOptions,
           {
             type: TokenType.siopIssuance,
             audience: this._audienceUrl,
-            realm: VerifiableCredentialConstants.TOKEN_SI_ISS
           })
       };
     }

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -14,9 +14,14 @@ import IFetchRequest from '../tracing/IFetchRequest';
  * Class to build a token validator
  */
 export default class ValidatorBuilder {
+  /**
+   * The default behavior when we encounter an invalid status code
+   */
+  public static readonly INVALID_TOKEN_STATUS_CODE = 401;
+
   private _tokenValidators: ({ [type: string]: ITokenValidator }) | undefined;
-  
-  private _trustedIssuersForVerifiableCredentials:  {[credentialType: string]: string[]} | undefined;
+
+  private _trustedIssuersForVerifiableCredentials: { [credentialType: string]: string[] } | undefined;
   private _trustedIssuerConfigurationsForIdTokens: IssuerMap | undefined;
   private _audienceUrl: string | undefined;
   private _requestor: Requestor | undefined;
@@ -25,13 +30,14 @@ export default class ValidatorBuilder {
   private _fetchRequest: IFetchRequest = new FetchRequest();
   private _resolver: IDidResolver = new ManagedHttpResolver(VerifiableCredentialConstants.UNIVERSAL_RESOLVER_URL, this._fetchRequest);
   private _validationSafeguards: ValidationSafeguards = new ValidationSafeguards();
-  private _invalidTokenError: number = 401;
+  private _invalidTokenError: number;
 
   /**
    * Create a new instance of ValidatorBuilder
    * @param _crypto The crypto object
    */
   constructor(private _crypto: Crypto) {
+    this._invalidTokenError = ValidatorBuilder.INVALID_TOKEN_STATUS_CODE;
   }
 
   /**
@@ -61,11 +67,11 @@ export default class ValidatorBuilder {
     };
   }
 
- /**
-   * Sets the state
-   * @param state The state for the response
-   * @returns The validator builder
-   */
+  /**
+    * Sets the state
+    * @param state The state for the response
+    * @returns The validator builder
+    */
   public useState(state: string): ValidatorBuilder {
     this._state = state;
     return this;
@@ -83,7 +89,7 @@ export default class ValidatorBuilder {
     * @param nonce The nonce for the response
     * @returns The validator builder
     */
-   public useNonce(nonce: string): ValidatorBuilder {
+  public useNonce(nonce: string): ValidatorBuilder {
     this._nonce = nonce;
     return this;
   }
@@ -111,7 +117,7 @@ export default class ValidatorBuilder {
     if (!this._nonce && requestor.builder.nonce) {
       this._nonce = requestor.builder.nonce;
     }
-    
+
     return this;
   }
 
@@ -151,14 +157,20 @@ export default class ValidatorBuilder {
       const validatorOptions: IValidatorOptions = this.validationOptions;
 
       this._tokenValidators = {
-        selfIssued: new SelfIssuedTokenValidator(validatorOptions, <IExpectedSelfIssued> {type: TokenType.selfIssued}),
-        idToken: new IdTokenTokenValidator(validatorOptions, <IExpectedIdToken> {type: TokenType.idToken, configuration: this._trustedIssuerConfigurationsForIdTokens}),
-        verifiableCredential: new VerifiableCredentialTokenValidator(validatorOptions, <IExpectedVerifiableCredential> {type: TokenType.verifiableCredential, contractIssuers: this._trustedIssuersForVerifiableCredentials}),
-        verifiablePresentationJwt: new VerifiablePresentationTokenValidator(validatorOptions, <IExpectedVerifiablePresentation> {type: TokenType.verifiablePresentationJwt, didAudience: this.crypto.builder.did}),
-        siopPresentationAttestation: new SiopTokenValidator(validatorOptions, <IExpectedSiop> {type: TokenType.siopPresentationAttestation, audience: this._audienceUrl}),
-        siop: new SiopTokenValidator(validatorOptions, <IExpectedSiop> {type: TokenType.siop, audience: this._audienceUrl}),
-        siopPresentationExchange: new SiopTokenValidator(validatorOptions, <IExpectedSiop> {type: TokenType.siopPresentationExchange, audience: this._audienceUrl}),
-        siopIssuance: new SiopTokenValidator(validatorOptions, <IExpectedSiop> {type: TokenType.siopIssuance, audience: this._audienceUrl})
+        selfIssued: new SelfIssuedTokenValidator(validatorOptions, <IExpectedSelfIssued>{ type: TokenType.selfIssued }),
+        idToken: new IdTokenTokenValidator(validatorOptions, <IExpectedIdToken>{ type: TokenType.idToken, configuration: this._trustedIssuerConfigurationsForIdTokens }),
+        verifiableCredential: new VerifiableCredentialTokenValidator(validatorOptions, <IExpectedVerifiableCredential>{ type: TokenType.verifiableCredential, contractIssuers: this._trustedIssuersForVerifiableCredentials }),
+        verifiablePresentationJwt: new VerifiablePresentationTokenValidator(validatorOptions, <IExpectedVerifiablePresentation>{ type: TokenType.verifiablePresentationJwt, didAudience: this.crypto.builder.did }),
+        siopPresentationAttestation: new SiopTokenValidator(validatorOptions, <IExpectedSiop>{ type: TokenType.siopPresentationAttestation, audience: this._audienceUrl }),
+        siop: new SiopTokenValidator(
+          validatorOptions, 
+          { 
+            type: TokenType.siop, 
+            audience: this._audienceUrl, 
+            realm: VerifiableCredentialConstants.TOKEN_SI_ISS 
+          }),
+        siopPresentationExchange: new SiopTokenValidator(validatorOptions, <IExpectedSiop>{ type: TokenType.siopPresentationExchange, audience: this._audienceUrl }),
+        siopIssuance: new SiopTokenValidator(validatorOptions, <IExpectedSiop>{ type: TokenType.siopIssuance, audience: this._audienceUrl })
       };
     }
 
@@ -172,7 +184,7 @@ export default class ValidatorBuilder {
    */
   public useFetchRequest(fetchRequest: IFetchRequest): ValidatorBuilder {
     (<any>this.resolver).fetchRequest = this._fetchRequest = fetchRequest;
-     
+
     return this;
   }
 
@@ -204,13 +216,17 @@ export default class ValidatorBuilder {
    * 
    * @param issuers array of issuers
    */
-  public useTrustedIssuersForVerifiableCredentials(issuers: {[credentialType: string]: string[]}): ValidatorBuilder {
+  public useTrustedIssuersForVerifiableCredentials(issuers: { [credentialType: string]: string[] }): ValidatorBuilder {
     this._trustedIssuersForVerifiableCredentials = issuers;
     if (this._tokenValidators) {
       // Make sure existing expected gets updated
       const vcValidator = this._tokenValidators[TokenType.verifiableCredential];
       if (vcValidator) {
-        const expected: IExpectedVerifiableCredential = {type: TokenType.verifiableCredential, contractIssuers: issuers};
+        const expected: IExpectedVerifiableCredential = {
+          type: TokenType.verifiableCredential,
+          contractIssuers: issuers
+        };
+
         this._tokenValidators[TokenType.verifiableCredential] = new VerifiableCredentialTokenValidator(this.validationOptions, expected);
       }
     }
@@ -221,7 +237,7 @@ export default class ValidatorBuilder {
    * Specify the trusted issuer for the verifiable credentials
    * @param issuers array of issuers or dictionary mapped to credential type
    */
-  public get trustedIssuersForVerifiableCredentials():  {[credentialType: string]: string[]} | undefined {
+  public get trustedIssuersForVerifiableCredentials(): { [credentialType: string]: string[] } | undefined {
     return this._trustedIssuersForVerifiableCredentials;
   }
 
@@ -235,7 +251,7 @@ export default class ValidatorBuilder {
       // Make sure existing expected gets updated
       const idtokenValidator = this._tokenValidators[TokenType.idToken];
       if (idtokenValidator) {
-        const expected: IExpectedIdToken = {type: TokenType.idToken, configuration: issuers};
+        const expected: IExpectedIdToken = { type: TokenType.idToken, configuration: issuers };
         this._tokenValidators[TokenType.idToken] = new IdTokenTokenValidator(this.validationOptions, expected);
       }
     }

--- a/lib/api_validation/ValidatorBuilder.ts
+++ b/lib/api_validation/ValidatorBuilder.ts
@@ -25,6 +25,7 @@ export default class ValidatorBuilder {
   private _fetchRequest: IFetchRequest = new FetchRequest();
   private _resolver: IDidResolver = new ManagedHttpResolver(VerifiableCredentialConstants.UNIVERSAL_RESOLVER_URL, this._fetchRequest);
   private _validationSafeguards: ValidationSafeguards = new ValidationSafeguards();
+  private _invalidTokenError: number = 401;
 
   /**
    * Create a new instance of ValidatorBuilder
@@ -55,7 +56,8 @@ export default class ValidatorBuilder {
       resolver: this.resolver,
       fetchRequest: this.fetchRequest,
       validationSafeguards: this._validationSafeguards,
-      crypto: this.crypto
+      crypto: this.crypto,
+      invalidTokenError: this._invalidTokenError,
     };
   }
 
@@ -324,6 +326,16 @@ export default class ValidatorBuilder {
    */
   public useMaxSizeOfIdToken(value: number): ValidatorBuilder {
     this._validationSafeguards.maxSizeOfIdToken = value;
+    return this;
+  }
+
+  /**
+   * Sets the error value when a token is determined to be invalid
+   * @param value value to return when an invalid token is encountered
+   * @returns ValidatorBuilder instance
+   */
+  public invalidTokensFailWith(value: number): ValidatorBuilder {
+    this._invalidTokenError = value;
     return this;
   }
 

--- a/lib/error_handling/AuthenticationErrorCode.ts
+++ b/lib/error_handling/AuthenticationErrorCode.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export enum AuthenticationErrorCode {
+  /**
+   * Error code for a missing or malformed token
+   * https://tools.ietf.org/html/rfc6750#section-3.1
+   */
+  invalidRequest = 'invalid_request',
+
+  /**
+   * Error code for a invalid (e.g. expired, revoked) token
+   * https://tools.ietf.org/html/rfc6750#section-3.1
+   */
+  invalidToken = 'invalid_token',
+}
+
+export enum AuthenticationErrorDescription {
+  /**
+   * When an expected token is malformed such as a jwt that is not a jwt or a json that does not parse
+   */
+  malformedToken = 'The token is malformed',
+}

--- a/lib/error_handling/AuthenticationErrorCode.ts
+++ b/lib/error_handling/AuthenticationErrorCode.ts
@@ -5,12 +5,14 @@
 export enum AuthenticationErrorCode {
   /**
    * Error code for a missing or malformed token
+   * Unable to validate a token
    * https://tools.ietf.org/html/rfc6750#section-3.1
    */
   invalidRequest = 'invalid_request',
 
   /**
    * Error code for a invalid (e.g. expired, revoked) token
+   * Inflection point is that there was a valid attempt to validate a token
    * https://tools.ietf.org/html/rfc6750#section-3.1
    */
   invalidToken = 'invalid_token',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -133,3 +133,9 @@ export {
   JsonWebSignatureToken,
   TokenPayload,
 };
+
+import { AuthenticationErrorDescription, AuthenticationErrorCode} from './error_handling/AuthenticationErrorCode';
+export {
+  AuthenticationErrorDescription,
+  AuthenticationErrorCode,
+}

--- a/lib/input_validation/DidValidation.ts
+++ b/lib/input_validation/DidValidation.ts
@@ -33,7 +33,6 @@ export class DidValidation implements IDidValidation {
     let validationResponse: IDidValidationResponse = {
       result: true,
       status: 200,
-      realm: this.expected.realm,
     };
 
     // Deserialize the token
@@ -51,7 +50,6 @@ export class DidValidation implements IDidValidation {
          detailedError: `The kid in the protected header does not contain the DID. Required format for kid is <did>#kid`,
          status: this.options.validatorOptions.invalidTokenError,
          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
-         realm: this.expected.realm,
        };
      }
      validationResponse.did = parts[0];
@@ -63,7 +61,6 @@ export class DidValidation implements IDidValidation {
           detailedError: 'The kid does not contain the DID',
           status: this.options.validatorOptions.invalidTokenError,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
-          realm: this.expected.realm,
          };
     }
 

--- a/lib/input_validation/DidValidation.ts
+++ b/lib/input_validation/DidValidation.ts
@@ -8,6 +8,7 @@ import { IDidValidation, IDidValidationResponse } from './DidValidationResponse'
 import { IValidationOptions } from '../options/IValidationOptions';
 import { IExpectedBase } from '../index';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
+import { AuthenticationErrorCode } from '../error_handling/AuthenticationErrorCode';
 const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKDIDV', error);
 
 /**
@@ -47,7 +48,8 @@ export class DidValidation implements IDidValidation {
          result: false,
          code: errorCode(1),
          detailedError: `The kid in the protected header does not contain the DID. Required format for kid is <did>#kid`,
-         status: 403
+         status: this.options.validatorOptions.invalidTokenError,
+         wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
        };
      }
      validationResponse.did = parts[0];
@@ -57,8 +59,9 @@ export class DidValidation implements IDidValidation {
           result: false,
           code: errorCode(2),
           detailedError: 'The kid does not contain the DID',
-          status: 403
-        };
+          status: this.options.validatorOptions.invalidTokenError,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
+         };
     }
 
    // Resolve DID, get document and retrieve public key

--- a/lib/input_validation/DidValidation.ts
+++ b/lib/input_validation/DidValidation.ts
@@ -32,7 +32,8 @@ export class DidValidation implements IDidValidation {
   public async validate (token: string | object): Promise<IDidValidationResponse> {
     let validationResponse: IDidValidationResponse = {
       result: true,
-      status: 200
+      status: 200,
+      realm: this.expected.realm,
     };
 
     // Deserialize the token
@@ -50,6 +51,7 @@ export class DidValidation implements IDidValidation {
          detailedError: `The kid in the protected header does not contain the DID. Required format for kid is <did>#kid`,
          status: this.options.validatorOptions.invalidTokenError,
          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
+         realm: this.expected.realm,
        };
      }
      validationResponse.did = parts[0];
@@ -61,6 +63,7 @@ export class DidValidation implements IDidValidation {
           detailedError: 'The kid does not contain the DID',
           status: this.options.validatorOptions.invalidTokenError,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
+          realm: this.expected.realm,
          };
     }
 

--- a/lib/input_validation/IValidationResponse.ts
+++ b/lib/input_validation/IValidationResponse.ts
@@ -98,11 +98,6 @@ export interface IValidationResponse extends IResponse {
   expiration?: number;
 
   /**
-   * the realm value when a token fails to validate
-   */
-  realm?: string;
-
-  /**
    * Error for the WWW-Authenticate header error field
    */
   wwwAuthenticateError?: string;

--- a/lib/input_validation/IValidationResponse.ts
+++ b/lib/input_validation/IValidationResponse.ts
@@ -96,4 +96,14 @@ export interface IValidationResponse extends IResponse {
    * The epoch expiration time
    */
   expiration?: number;
+
+  /**
+   * the realm value when a token fails to validate
+   */
+  realm?: string;
+
+  /**
+   * Error for the WWW-Authenticate header error field
+   */
+  wwwAuthenticateError?: string;
 }

--- a/lib/input_validation/SiopValidation.ts
+++ b/lib/input_validation/SiopValidation.ts
@@ -52,7 +52,7 @@ export class SiopValidation implements ISiopValidation {
     }
 
     // Check token scope (aud and iss)
-    validationResponse = await this.options.checkScopeValidityOnSiopTokenDelegate(validationResponse, this.expected);
+    validationResponse = this.options.checkScopeValidityOnSiopTokenDelegate(validationResponse, this.expected);
     if (!validationResponse.result) {
       return validationResponse;
     }

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -73,7 +73,6 @@ export class ValidationHelpers {
           detailedError: `The ${(self as ValidationOptions).tokenType} could not be deserialized`,
           innerError: exception,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
@@ -85,7 +84,6 @@ export class ValidationHelpers {
         code: errorCode(2),
         detailedError: `The signature in the ${(self as ValidationOptions).tokenType} has an invalid format`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
@@ -98,7 +96,6 @@ export class ValidationHelpers {
           code: errorCode(3),
           detailedError: `The payload in the ${(self as ValidationOptions).tokenType} is undefined`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
@@ -113,7 +110,6 @@ export class ValidationHelpers {
           innerError: err,
           detailedError: `The payload in the ${(self as ValidationOptions).tokenType} is no valid JSON`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
@@ -125,7 +121,6 @@ export class ValidationHelpers {
           code: errorCode(5),
           detailedError: `The protected header in the ${(self as ValidationOptions).tokenType} does not contain the kid`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
@@ -148,7 +143,6 @@ export class ValidationHelpers {
           code: errorCode(6),
           detailedError: `The proof is not available in the json ld payload`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
@@ -158,7 +152,6 @@ export class ValidationHelpers {
           code: errorCode(7),
           detailedError: `The proof does not contain the verificationMethod in the json ld payload`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
@@ -188,7 +181,6 @@ export class ValidationHelpers {
           code: errorCode(8),
           detailedError: `Could not retrieve DID document '${validationResponse.did}'`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         }
       }
@@ -202,7 +194,6 @@ export class ValidationHelpers {
         innerError: err,
         detailedError: `Could not resolve DID '${validationResponse.did}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -214,7 +205,6 @@ export class ValidationHelpers {
         code: errorCode(10),
         detailedError: `The kid is not referenced in the request`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
@@ -229,7 +219,6 @@ export class ValidationHelpers {
         detailedError: exception.message,
         innerError: exception,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -291,7 +280,6 @@ export class ValidationHelpers {
           code: errorCode(12),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is expired ${exp}, now ${current as number}`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
@@ -309,7 +297,6 @@ export class ValidationHelpers {
           code: errorCode(40),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is not yet valid ${nbf}`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
@@ -334,7 +321,6 @@ export class ValidationHelpers {
         code: errorCode(13),
         detailedError: `The issuer in configuration was not found`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -345,7 +331,6 @@ export class ValidationHelpers {
         code: errorCode(14),
         detailedError: `Missing iss property in idToken. Expected '${JSON.stringify(issuer)}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -356,7 +341,6 @@ export class ValidationHelpers {
         code: errorCode(15),
         detailedError: `The issuer in configuration '${issuer}' does not correspond with the issuer in the payload ${validationResponse.issuer}`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -368,7 +352,6 @@ export class ValidationHelpers {
         code: errorCode(16),
         detailedError: `The audience ${validationResponse.payloadObject.aud} is invalid`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -393,7 +376,6 @@ export class ValidationHelpers {
         code: errorCode(17),
         detailedError: `Missing iss property in verifiablePresentation. Expected '${siopDid}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -404,7 +386,6 @@ export class ValidationHelpers {
         code: errorCode(18),
         detailedError: `Wrong iss property in verifiablePresentation. Expected '${siopDid}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -417,7 +398,6 @@ export class ValidationHelpers {
           code: errorCode(19),
           detailedError: `Missing aud property in verifiablePresentation. Expected '${expected.didAudience}'`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
@@ -428,7 +408,6 @@ export class ValidationHelpers {
           code: errorCode(20),
           detailedError: `Wrong aud property in verifiablePresentation. Expected '${expected.didAudience}'. Found '${validationResponse.payloadObject.aud}'`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
@@ -454,7 +433,6 @@ export class ValidationHelpers {
         code: errorCode(21),
         detailedError: `Missing sub property in verifiableCredential. Expected '${siopDid}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -466,7 +444,6 @@ export class ValidationHelpers {
         code: errorCode(22),
         detailedError: `Wrong sub property in verifiableCredential. Expected '${siopDid}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -490,7 +467,6 @@ export class ValidationHelpers {
         code: errorCode(23),
         detailedError: `Missing iss property in siop. Expected '${VerifiableCredentialConstants.TOKEN_SI_ISS}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
@@ -501,7 +477,6 @@ export class ValidationHelpers {
         code: errorCode(24),
         detailedError: `Wrong iss property in siop. Expected '${VerifiableCredentialConstants.TOKEN_SI_ISS}'`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -513,7 +488,6 @@ export class ValidationHelpers {
         code: errorCode(25),
         detailedError: `Missing aud property in siop`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
@@ -525,7 +499,6 @@ export class ValidationHelpers {
           code: errorCode(26),
           detailedError: `Wrong aud property in siop. Expected '${expected.audience}'`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
@@ -551,7 +524,6 @@ export class ValidationHelpers {
           code: errorCode(27),
           detailedError: `The signature on the payload in the ${(self as ValidationOptions).tokenType} is invalid`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
@@ -563,7 +535,6 @@ export class ValidationHelpers {
         detailedError: `Failed to validate signature`,
         innerError: err,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -596,7 +567,6 @@ export class ValidationHelpers {
             code: errorCode(29),
             detailedError: `Could not fetch token configuration needed to validate token`,
             status: this.validatorOptions.invalidTokenError,
-            realm: validationResponse.realm,
             wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
@@ -610,7 +580,6 @@ export class ValidationHelpers {
             code: errorCode(30),
             detailedError: `No reference to jwks found in token configuration`,
             status: this.validatorOptions.invalidTokenError,
-            realm: validationResponse.realm,
             wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
@@ -628,7 +597,6 @@ export class ValidationHelpers {
             code: errorCode(31),
             detailedError: `Could not fetch keys needed to validate token on '${keysUrl}'`,
             status: this.validatorOptions.invalidTokenError,
-            realm: validationResponse.realm,
             wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
@@ -641,7 +609,6 @@ export class ValidationHelpers {
             code: errorCode(32),
             detailedError: `No or bad jwks keys found in token configuration`,
             status: this.validatorOptions.invalidTokenError,
-            realm: validationResponse.realm,
             wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
@@ -654,7 +621,6 @@ export class ValidationHelpers {
             code: errorCode(33),
             detailedError: `No issuer found in token configuration`,
             status: this.validatorOptions.invalidTokenError,
-            realm: validationResponse.realm,
             wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
@@ -667,7 +633,6 @@ export class ValidationHelpers {
         code: errorCode(34),
         detailedError: `Could not fetch token configuration`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -727,7 +692,6 @@ export class ValidationHelpers {
             code: errorCode(35),
             detailedError: `Could not validate token signature`,
             status: this.validatorOptions.invalidTokenError,
-            realm: validationResponse.realm,
             wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
@@ -746,7 +710,6 @@ export class ValidationHelpers {
         innerError: err,
         detailedError: `Could not validate signature on id token`,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
@@ -771,7 +734,6 @@ export class ValidationHelpers {
           code: errorCode(37),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is has an invalid signature`,
           status: this.validatorOptions.invalidTokenError,
-          realm: validationResponse.realm,
           wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
@@ -787,7 +749,6 @@ export class ValidationHelpers {
         detailedError: `Failed to verify token signature`,
         innerError: err,
         status: this.validatorOptions.invalidTokenError,
-        realm: validationResponse.realm,
         wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }

--- a/lib/input_validation/ValidationHelpers.ts
+++ b/lib/input_validation/ValidationHelpers.ts
@@ -15,6 +15,7 @@ import { IExpectedVerifiablePresentation, IExpectedVerifiableCredential, IExpect
 import LinkedDataCryptoSuitePublicKey from './LinkedDataCryptoSuitePublicKey';
 import ErrorHelpers from '../error_handling/ErrorHelpers';
 import ValidationError from '../error_handling/ValidationError';
+import { AuthenticationErrorCode } from '../error_handling/AuthenticationErrorCode';
 const errorCode = (error: number) => ErrorHelpers.errorCode('VCSDKVaHe', error);
 
 require('es6-promise').polyfill();
@@ -71,7 +72,9 @@ export class ValidationHelpers {
           code: errorCode(1),
           detailedError: `The ${(self as ValidationOptions).tokenType} could not be deserialized`,
           innerError: exception,
-          status: 400
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
     }
@@ -81,7 +84,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(2),
         detailedError: `The signature in the ${(self as ValidationOptions).tokenType} has an invalid format`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
 
@@ -92,7 +97,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(3),
           detailedError: `The payload in the ${(self as ValidationOptions).tokenType} is undefined`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
 
@@ -105,7 +112,9 @@ export class ValidationHelpers {
           code: errorCode(4),
           innerError: err,
           detailedError: `The payload in the ${(self as ValidationOptions).tokenType} is no valid JSON`,
-          status: 400
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
 
@@ -115,7 +124,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(5),
           detailedError: `The protected header in the ${(self as ValidationOptions).tokenType} does not contain the kid`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
 
@@ -136,7 +147,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(6),
           detailedError: `The proof is not available in the json ld payload`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
       if (!proof.verificationMethod) {
@@ -144,7 +157,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(7),
           detailedError: `The proof does not contain the verificationMethod in the json ld payload`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
         };
       }
       validationResponse.didKid = proof.verificationMethod;
@@ -172,7 +187,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(8),
           detailedError: `Could not retrieve DID document '${validationResponse.did}'`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         }
       }
       validationResponse.didDocument = resolveResult.didDocument;
@@ -184,7 +201,9 @@ export class ValidationHelpers {
         code: errorCode(9),
         innerError: err,
         detailedError: `Could not resolve DID '${validationResponse.did}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -194,7 +213,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(10),
         detailedError: `The kid is not referenced in the request`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
 
@@ -207,7 +228,9 @@ export class ValidationHelpers {
         code: errorCode(11),
         detailedError: exception.message,
         innerError: exception,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -225,11 +248,11 @@ export class ValidationHelpers {
     if (publicKey) {
       // Old ion protocol, to be deleted after switch
       signingKey = LinkedDataCryptoSuitePublicKey.getPublicKey(publicKey);
-    } else { 
+    } else {
       if (didDocument.rawDocument?.verificationMethod) {
         const keyIdParts = kid.split('#');
         const keyId = keyIdParts[keyIdParts.length - 1];
-        const verification = didDocument.rawDocument?.verificationMethod.filter ((vm: any) => vm.id.includes(`#${keyId}`));
+        const verification = didDocument.rawDocument?.verificationMethod.filter((vm: any) => vm.id.includes(`#${keyId}`));
         if (verification) {
           signingKey = LinkedDataCryptoSuitePublicKey.getPublicKey(verification[0]);
         }
@@ -267,7 +290,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(12),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is expired ${exp}, now ${current as number}`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
     }
@@ -283,7 +308,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(40),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is not yet valid ${nbf}`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
     }
@@ -306,7 +333,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(13),
         detailedError: `The issuer in configuration was not found`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -315,7 +344,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(14),
         detailedError: `Missing iss property in idToken. Expected '${JSON.stringify(issuer)}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -324,7 +355,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(15),
         detailedError: `The issuer in configuration '${issuer}' does not correspond with the issuer in the payload ${validationResponse.issuer}`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -332,9 +365,11 @@ export class ValidationHelpers {
     if (expected.audience && expected.audience !== validationResponse.payloadObject.aud) {
       return {
         result: false,
-        status: 401,
         code: errorCode(16),
-        detailedError: `The audience ${validationResponse.payloadObject.aud} is invalid`
+        detailedError: `The audience ${validationResponse.payloadObject.aud} is invalid`,
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -357,7 +392,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(17),
         detailedError: `Missing iss property in verifiablePresentation. Expected '${siopDid}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -366,7 +403,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(18),
         detailedError: `Wrong iss property in verifiablePresentation. Expected '${siopDid}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -377,7 +416,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(19),
           detailedError: `Missing aud property in verifiablePresentation. Expected '${expected.didAudience}'`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
 
@@ -386,7 +427,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(20),
           detailedError: `Wrong aud property in verifiablePresentation. Expected '${expected.didAudience}'. Found '${validationResponse.payloadObject.aud}'`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
     }
@@ -410,7 +453,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(21),
         detailedError: `Missing sub property in verifiableCredential. Expected '${siopDid}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -420,7 +465,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(22),
         detailedError: `Wrong sub property in verifiableCredential. Expected '${siopDid}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -436,24 +483,15 @@ export class ValidationHelpers {
   public checkScopeValidityOnSiopToken(validationResponse: IValidationResponse, expected: IExpectedSiop): IValidationResponse {
     const self: any = this;
 
-    // check sub
-    /* TODO temporary disabled
-    if (validationResponse.payloadObject.sub && validationResponse.payloadObject.sub !== validationResponse.did) {
-      return {
-        result: false,
-        detailedError: `The sub property in the siopIssuance must be equal to ${validationResponse.did}`,
-        status: 403
-      };
-    }
-    */
-
     // check iss value
     if (!validationResponse.issuer) {
       return validationResponse = {
         result: false,
         code: errorCode(23),
         detailedError: `Missing iss property in siop. Expected '${VerifiableCredentialConstants.TOKEN_SI_ISS}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
 
@@ -462,7 +500,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(24),
         detailedError: `Wrong iss property in siop. Expected '${VerifiableCredentialConstants.TOKEN_SI_ISS}'`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -472,7 +512,9 @@ export class ValidationHelpers {
         result: false,
         code: errorCode(25),
         detailedError: `Missing aud property in siop`,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidRequest,
       };
     }
 
@@ -482,7 +524,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(26),
           detailedError: `Wrong aud property in siop. Expected '${expected.audience}'`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
     }
@@ -506,7 +550,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(27),
           detailedError: `The signature on the payload in the ${(self as ValidationOptions).tokenType} is invalid`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
     } catch (err) {
@@ -516,7 +562,9 @@ export class ValidationHelpers {
         code: errorCode(28),
         detailedError: `Failed to validate signature`,
         innerError: err,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -539,52 +587,62 @@ export class ValidationHelpers {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json'
-          }});
+          }
+        });
 
         if (!response.ok) {
           return {
             result: false,
-            status: 403,
             code: errorCode(29),
-            detailedError: `Could not fetch token configuration needed to validate token`
+            detailedError: `Could not fetch token configuration needed to validate token`,
+            status: this.validatorOptions.invalidTokenError,
+            realm: validationResponse.realm,
+            wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
-        
+
         const config = await response.json();
         const keysUrl = config[VerifiableCredentialConstants.CONFIG_JWKS];
-        
+
         if (!keysUrl) {
           return {
             result: false,
-            status: 403,
             code: errorCode(30),
-            detailedError: `No reference to jwks found in token configuration`
+            detailedError: `No reference to jwks found in token configuration`,
+            status: this.validatorOptions.invalidTokenError,
+            realm: validationResponse.realm,
+            wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
-        
+
         response = await this.validatorOptions.fetchRequest.fetch(keysUrl, 'OIDCJwks', {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json'
-          }});
-          
+          }
+        });
+
         if (!response.ok) {
           return {
             result: false,
-            status: 403,
             code: errorCode(31),
-            detailedError: `Could not fetch keys needed to validate token on '${keysUrl}'`
+            detailedError: `Could not fetch keys needed to validate token on '${keysUrl}'`,
+            status: this.validatorOptions.invalidTokenError,
+            realm: validationResponse.realm,
+            wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
 
         keys = await response.json();
-        
+
         if (!keys || !keys.keys) {
           return {
             result: false,
-            status: 403,
             code: errorCode(32),
-            detailedError: `No or bad jwks keys found in token configuration`
+            detailedError: `No or bad jwks keys found in token configuration`,
+            status: this.validatorOptions.invalidTokenError,
+            realm: validationResponse.realm,
+            wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
 
@@ -593,9 +651,11 @@ export class ValidationHelpers {
         if (!config.issuer) {
           return {
             result: false,
-            status: 403,
             code: errorCode(33),
-            detailedError: `No issuer found in token configuration`
+            detailedError: `No issuer found in token configuration`,
+            status: this.validatorOptions.invalidTokenError,
+            realm: validationResponse.realm,
+            wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
       }
@@ -603,10 +663,12 @@ export class ValidationHelpers {
       console.error(err);
       return {
         result: false,
-        status: 403,
         innerError: err,
         code: errorCode(34),
-        detailedError: `Could not fetch token configuration`
+        detailedError: `Could not fetch token configuration`,
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
 
@@ -620,12 +682,12 @@ export class ValidationHelpers {
    * @returns validationResponse.issuer The issuer found in the configuration. Should match the issuer in the token.
    */
   public async fetchKeyAndValidateSignatureOnIdToken(validationResponse: IValidationResponse, token: ClaimToken): Promise<IValidationResponse> {
-    const self: any = this ;
+    const self: any = this;
     const publicKeyResponse = await (self as IValidationOptions).fetchOpenIdTokenPublicKeysDelegate(validationResponse, token);
 
     // if we don't have a keys property, it's because we have IValidationResponse instance, no good way to check for type of an interface
-    if(!publicKeyResponse.keys) {
-      return <IValidationResponse> publicKeyResponse;
+    if (!publicKeyResponse.keys) {
+      return <IValidationResponse>publicKeyResponse;
     }
 
     const keys = publicKeyResponse.keys;
@@ -662,9 +724,11 @@ export class ValidationHelpers {
         if (!validated) {
           return {
             result: false,
-            status: 403,
             code: errorCode(35),
-            detailedError: `Could not validate token signature`
+            detailedError: `Could not validate token signature`,
+            status: this.validatorOptions.invalidTokenError,
+            realm: validationResponse.realm,
+            wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
           };
         }
       }
@@ -678,10 +742,12 @@ export class ValidationHelpers {
       console.error(err);
       return {
         result: false,
-        status: 403,
         code: errorCode(36),
         innerError: err,
-        detailedError: `Could not validate signature on id token`
+        detailedError: `Could not validate signature on id token`,
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
   }
@@ -704,7 +770,9 @@ export class ValidationHelpers {
           result: false,
           code: errorCode(37),
           detailedError: `The presented ${(self as ValidationOptions).tokenType} is has an invalid signature`,
-          status: 403
+          status: this.validatorOptions.invalidTokenError,
+          realm: validationResponse.realm,
+          wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
         };
       }
 
@@ -718,7 +786,9 @@ export class ValidationHelpers {
         code: errorCode(38),
         detailedError: `Failed to verify token signature`,
         innerError: err,
-        status: 403
+        status: this.validatorOptions.invalidTokenError,
+        realm: validationResponse.realm,
+        wwwAuthenticateError: AuthenticationErrorCode.invalidToken,
       };
     }
   }

--- a/lib/options/BasicValidatorOptions.ts
+++ b/lib/options/BasicValidatorOptions.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Crypto, IDidResolver, CryptoBuilder, IFetchRequest, FetchRequest, ValidationSafeguards } from '../index';
+import { Crypto, IDidResolver, CryptoBuilder, IFetchRequest, FetchRequest, ValidationSafeguards, ValidatorBuilder } from '../index';
 import IValidatorOptions from './IValidatorOptions';
 
 /**
@@ -19,7 +19,7 @@ export default class BasicValidatorOptions implements IValidatorOptions {
     this._crypto = new CryptoBuilder().build();
     this._fetchRequest = new FetchRequest();
     this._validationSafeguards = new ValidationSafeguards();
-    this._invalidTokenError = 401;
+    this._invalidTokenError = ValidatorBuilder.INVALID_TOKEN_STATUS_CODE;
   }
   
   get invalidTokenError(): number {

--- a/lib/options/BasicValidatorOptions.ts
+++ b/lib/options/BasicValidatorOptions.ts
@@ -13,11 +13,17 @@ export default class BasicValidatorOptions implements IValidatorOptions {
   private readonly _crypto: Crypto;
   private readonly _fetchRequest: IFetchRequest;
   private readonly _validationSafeguards: ValidationSafeguards;
+  private readonly _invalidTokenError: number;
 
   constructor(private _resolver?: IDidResolver) {
     this._crypto = new CryptoBuilder().build();
     this._fetchRequest = new FetchRequest();
     this._validationSafeguards = new ValidationSafeguards();
+    this._invalidTokenError = 401;
+  }
+  
+  get invalidTokenError(): number {
+    return this._invalidTokenError;
   }
 
   get resolver(): IDidResolver {

--- a/lib/options/IExpected.ts
+++ b/lib/options/IExpected.ts
@@ -20,7 +20,12 @@ export interface IExpectedBase {
   /**
    * The token type
    */
-  type: TokenType
+  type: TokenType,
+
+  /**
+   * invalid token realm aka what token failed
+   */
+  realm?: string,
 }
 
 

--- a/lib/options/IExpected.ts
+++ b/lib/options/IExpected.ts
@@ -21,11 +21,6 @@ export interface IExpectedBase {
    * The token type
    */
   type: TokenType,
-
-  /**
-   * invalid token realm aka what token failed
-   */
-  realm?: string,
 }
 
 

--- a/lib/options/IValidatorOptions.ts
+++ b/lib/options/IValidatorOptions.ts
@@ -6,28 +6,33 @@
 import { IDidResolver, Crypto, ValidationSafeguards } from '../index';
 import IFetchRequest from '../tracing/IFetchRequest';
 
- /**
- * Interface to model the validator options
- */
+/**
+* Interface to model the validator options
+*/
 export default interface IValidatorOptions {
-    
-    /**
-     * The DID resolver
-     */
-    resolver: IDidResolver,
 
-    /**
-     * The fetch client
-     */
-    fetchRequest: IFetchRequest,
+  /**
+   * The DID resolver
+   */
+  resolver: IDidResolver,
 
-    /**
-     * The validation safeguards
-     */
-    validationSafeguards: ValidationSafeguards,
+  /**
+   * The fetch client
+   */
+  fetchRequest: IFetchRequest,
 
-    /**
-     * Get the crypto options
-     */
-    crypto: Crypto
+  /**
+   * The validation safeguards
+   */
+  validationSafeguards: ValidationSafeguards,
+
+  /**
+   * Get the crypto options
+   */
+  crypto: Crypto
+
+  /**
+   * Gets the error value of an invalid token
+   */ 
+  readonly invalidTokenError: number;
 }

--- a/lib/options/IValidatorOptions.ts
+++ b/lib/options/IValidatorOptions.ts
@@ -29,10 +29,10 @@ export default interface IValidatorOptions {
   /**
    * Get the crypto options
    */
-  crypto: Crypto
+  crypto: Crypto,
 
   /**
    * Gets the error value of an invalid token
    */ 
-  readonly invalidTokenError: number;
+  readonly invalidTokenError: number,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.7",
+  "version": "0.12.1-preview.8",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/DidValidation.spec.ts
+++ b/tests/DidValidation.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import TestSetup from './TestSetup';
-import { TokenType, IExpectedSiop } from '../lib/index';
+import { TokenType, IExpectedSiop, ValidatorBuilder } from '../lib/index';
 import { IssuanceHelpers } from './IssuanceHelpers';
 import { DidValidation } from '../lib/input_validation/DidValidation';
 import base64url from 'base64url';
@@ -33,7 +33,7 @@ describe('DidValidation', () =>
     // Bad VC signature
     response = await validator.validate(request.rawToken + 'a');
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The signature on the payload in the siopIssuance is invalid');
     expect(response.code).toEqual('VCSDKVaHe27');
 
@@ -41,7 +41,7 @@ describe('DidValidation', () =>
     let tokenParts =  (<string>request.rawToken).split('.');
     response = await validator.validate(`.${tokenParts[1]}.${tokenParts[2]}`);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(400);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The siopIssuance could not be deserialized');
     expect(response.code).toEqual('VCSDKVaHe01');
 
@@ -53,7 +53,7 @@ describe('DidValidation', () =>
     tokenParts =  (<string>request.rawToken).split('.');
     response = await validator.validate(`${base64url.encode(JSON.stringify(header))}.${tokenParts[1]}.${tokenParts[2]}`);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The protected header in the siopIssuance does not contain the kid');
     expect(response.code).toEqual('VCSDKVaHe05');
 

--- a/tests/DidValidation.spec.ts
+++ b/tests/DidValidation.spec.ts
@@ -66,7 +66,7 @@ describe('DidValidation', () =>
     tokenParts =  (<string>request.rawToken).split('.');
     response = await validator.validate(`${base64url.encode(JSON.stringify(header))}.${tokenParts[1]}.${tokenParts[2]}`);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(401);
     expect(response.detailedError).toEqual('The kid in the protected header does not contain the DID. Required format for kid is <did>#kid');
     expect(response.code).toEqual('VCSDKDIDV01');
 

--- a/tests/IdTokenValidation.spec.ts
+++ b/tests/IdTokenValidation.spec.ts
@@ -6,7 +6,7 @@ import TestSetup from './TestSetup';
 import { IdTokenValidation } from '../lib/input_validation/IdTokenValidation';
 import { IssuanceHelpers } from './IssuanceHelpers';
 import { TokenType } from '../lib/verifiable_credential/ClaimToken';
-import { IExpectedIdToken, Validator } from '../lib';
+import { IExpectedIdToken, Validator, ValidatorBuilder } from '../lib';
 
  describe('idTokenValidation', () => {
   let setup: TestSetup;
@@ -41,7 +41,7 @@ import { IExpectedIdToken, Validator } from '../lib';
     validator = new IdTokenValidation(options, expected, Validator.readContractId(siop.contract));
     response = await validator.validate( '.' + siop.idToken.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(400);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The idToken could not be deserialized');
     expect(response.code).toEqual('VCSDKVaHe01');
 
@@ -49,7 +49,7 @@ import { IExpectedIdToken, Validator } from '../lib';
     validator = new IdTokenValidation(options, expected, Validator.readContractId(siop.contract));
     response = await validator.validate(siop.idToken.rawToken + 'a');
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The presented idToken is has an invalid signature');
     expect(response.code).toEqual('VCSDKVaHe37');
 

--- a/tests/IssuanceHelpers.ts
+++ b/tests/IssuanceHelpers.ts
@@ -8,6 +8,7 @@ import { DidDocument } from '@decentralized-identity/did-common-typescript';
 import ClaimToken, { TokenType } from '../lib/verifiable_credential/ClaimToken';
 import ValidationOptions from '../lib/options/ValidationOptions';
 import { KeyReference, IExpectedBase, IExpectedSelfIssued, IExpectedIdToken, IExpectedSiop, IExpectedVerifiablePresentation, IExpectedVerifiableCredential, JsonWebSignatureToken, TokenPayload } from '../lib/index';
+import VerifiableCredentialConstants from '../lib/verifiable_credential/VerifiableCredentialConstants';
 
 export class IssuanceHelpers {
   public static readonly jti: string = 'testJti';
@@ -261,8 +262,8 @@ export class IssuanceHelpers {
     const expected: IExpectedBase[] = [
       <IExpectedSelfIssued>{ type: TokenType.selfIssued },
       <IExpectedIdToken>{ type: TokenType.idToken, configuration: idTokenConfiguration, audience: setup.AUDIENCE },
-      <IExpectedSiop>{ type: TokenType.siopIssuance, audience: setup.AUDIENCE },
-      <IExpectedSiop>{ type: TokenType.siopPresentationAttestation, audience: setup.AUDIENCE },
+      <IExpectedSiop>{ type: TokenType.siopIssuance, audience: setup.AUDIENCE, realm: VerifiableCredentialConstants.TOKEN_SI_ISS },
+      <IExpectedSiop>{ type: TokenType.siopPresentationAttestation, audience: setup.AUDIENCE, realm: VerifiableCredentialConstants.TOKEN_SI_ISS },
       <IExpectedVerifiablePresentation>{ type: TokenType.verifiablePresentationJwt, didAudience: setup.defaultIssuerDid },
       <IExpectedVerifiableCredential>{ type: TokenType.verifiableCredential, contractIssuers: vcContractIssuers }
     ];

--- a/tests/IssuanceHelpers.ts
+++ b/tests/IssuanceHelpers.ts
@@ -262,8 +262,8 @@ export class IssuanceHelpers {
     const expected: IExpectedBase[] = [
       <IExpectedSelfIssued>{ type: TokenType.selfIssued },
       <IExpectedIdToken>{ type: TokenType.idToken, configuration: idTokenConfiguration, audience: setup.AUDIENCE },
-      <IExpectedSiop>{ type: TokenType.siopIssuance, audience: setup.AUDIENCE, realm: VerifiableCredentialConstants.TOKEN_SI_ISS },
-      <IExpectedSiop>{ type: TokenType.siopPresentationAttestation, audience: setup.AUDIENCE, realm: VerifiableCredentialConstants.TOKEN_SI_ISS },
+      <IExpectedSiop>{ type: TokenType.siopIssuance, audience: setup.AUDIENCE },
+      <IExpectedSiop>{ type: TokenType.siopPresentationAttestation, audience: setup.AUDIENCE },
       <IExpectedVerifiablePresentation>{ type: TokenType.verifiablePresentationJwt, didAudience: setup.defaultIssuerDid },
       <IExpectedVerifiableCredential>{ type: TokenType.verifiableCredential, contractIssuers: vcContractIssuers }
     ];

--- a/tests/OpenIdTokenValidation.spec.ts
+++ b/tests/OpenIdTokenValidation.spec.ts
@@ -5,7 +5,7 @@
 import TestSetup from './TestSetup';
 import { IssuanceHelpers } from './IssuanceHelpers';
 import { TokenType } from '../lib/verifiable_credential/ClaimToken';
-import { OpenIdTokenValidation, IExpectedOpenIdToken } from '../lib';
+import { OpenIdTokenValidation, IExpectedOpenIdToken, ValidatorBuilder } from '../lib';
 
 describe('OpenIdTokenValidation', () => {
   let setup: TestSetup;
@@ -40,7 +40,7 @@ describe('OpenIdTokenValidation', () => {
     // Bad id token signature
     response = await validator.validate(siop.idToken.rawToken + 'a');
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The presented idToken is has an invalid signature');
     expect(response.code).toEqual('VCSDKVaHe37');
   });

--- a/tests/PresentationExchange.spec.ts
+++ b/tests/PresentationExchange.spec.ts
@@ -5,7 +5,7 @@
 
 import RequestorHelper from './RequestorHelper';
 import ResponderHelper from './ResponderHelper';
-import { ValidatorBuilder, PresentationDefinitionModel, IRequestorPresentationExchange, JoseBuilder, Validator } from '../lib';
+import { ValidatorBuilder, PresentationDefinitionModel, IRequestorPresentationExchange, JoseBuilder, Validator, AuthenticationErrorDescription } from '../lib';
 import TokenGenerator from './TokenGenerator';
 import PresentationDefinition from './models/PresentationDefinitionSample1'
 import RequestOneVcResponseOk from './models/RequestOneVcResponseOk'
@@ -75,7 +75,7 @@ describe('PresentationExchange', () => {
     siop = await (await responderHelper.crypto.signingProtocol(JoseBuilder.JWT).sign(responsePayload)).serialize();
     response = await validator!.validate(siop);
     expect(response.result).toBeFalsy(response.detailedError);
-    expect(response.detailedError).toEqual(`Not a valid SIOP`);
+    expect(response.detailedError).toEqual(AuthenticationErrorDescription.malformedToken);
     expect(response.code).toEqual('VCSDKSTVa05');
     
     //Remove tokens

--- a/tests/RuleProcessor.spec.ts
+++ b/tests/RuleProcessor.spec.ts
@@ -95,7 +95,7 @@ describe('Rule processor', () => {
       let response = await validator.validate(responderResponse);
       expect(response.result).toBeFalsy(response.detailedError);
       expect(response.code).toEqual('VCSDKSTVa05');
-      expect(response.status).toEqual(400);
+      expect(response.status).toEqual(401);
     } finally {
       TokenGenerator.fetchMock.reset();
     }

--- a/tests/RuleProcessor.spec.ts
+++ b/tests/RuleProcessor.spec.ts
@@ -168,7 +168,7 @@ describe('Rule processor', () => {
       let response = await validator.validate(responderResponse);
       expect(response.result).toBeFalsy(response.detailedError);
       expect(response.code).toEqual('VCSDKVaHe40');
-      expect(response.status).toEqual(403);
+      expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -196,7 +196,7 @@ describe('Rule processor', () => {
       let response = await validator.validate(responderResponse);
       expect(response.result).toBeFalsy(response.detailedError);
       expect(response.code).toEqual('VCSDKVaHe12');
-      expect(response.status).toEqual(403);
+      expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -225,7 +225,7 @@ describe('Rule processor', () => {
       let response = await validator.validate(responderResponse);
       expect(response.result).toBeFalsy(response.detailedError);
       expect(response.code).toEqual('VCSDKVaHe28');
-      expect(response.status).toEqual(403);
+      expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     } finally {
       TokenGenerator.fetchMock.reset();
     }
@@ -254,7 +254,7 @@ describe('Rule processor', () => {
       let response = await validator.validate(responderResponse);
       expect(response.result).toBeFalsy(response.detailedError);
       expect(response.code).toEqual('VCSDKVaHe28');
-      expect(response.status).toEqual(403);
+      expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     } finally {
       TokenGenerator.fetchMock.reset();
     }

--- a/tests/SiopValidation.spec.ts
+++ b/tests/SiopValidation.spec.ts
@@ -8,7 +8,7 @@ import { SiopValidation } from "../lib/input_validation/SiopValidation";
 import TestSetup from './TestSetup';
 import ValidationOptions from '../lib/options/ValidationOptions';
 import { IssuanceHelpers } from "./IssuanceHelpers";
-import { DidValidation, IExpectedSiop, TokenType } from "../lib/index";
+import { DidValidation, IExpectedSiop, TokenType, ValidatorBuilder } from "../lib/index";
 
 describe('SiopValidation', () =>
 {
@@ -39,7 +39,7 @@ describe('SiopValidation', () =>
     let siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Missing iss property in siop. Expected 'https://self-issued.me'`);
     expect(response.code).toEqual('VCSDKVaHe23');
 
@@ -50,7 +50,7 @@ describe('SiopValidation', () =>
     siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Wrong iss property in siop. Expected 'https://self-issued.me'`);
     expect(response.code).toEqual('VCSDKVaHe24');
 
@@ -61,7 +61,7 @@ describe('SiopValidation', () =>
     siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Missing aud property in siop`);
     expect(response.code).toEqual('VCSDKVaHe25');
 
@@ -73,7 +73,7 @@ describe('SiopValidation', () =>
     siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Wrong aud property in siop. Expected 'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/card/issue'`);
     expect(response.code).toEqual('VCSDKVaHe26');
 

--- a/tests/SiopValidation.spec.ts
+++ b/tests/SiopValidation.spec.ts
@@ -8,7 +8,8 @@ import { SiopValidation } from "../lib/input_validation/SiopValidation";
 import TestSetup from './TestSetup';
 import ValidationOptions from '../lib/options/ValidationOptions';
 import { IssuanceHelpers } from "./IssuanceHelpers";
-import { DidValidation, IExpectedSiop, TokenType, ValidatorBuilder } from "../lib/index";
+import { AuthenticationErrorCode, DidValidation, IExpectedSiop, TokenType, ValidatorBuilder } from "../lib/index";
+import VerifiableCredentialConstants from "../lib/verifiable_credential/VerifiableCredentialConstants";
 
 describe('SiopValidation', () =>
 {
@@ -42,6 +43,8 @@ describe('SiopValidation', () =>
     expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Missing iss property in siop. Expected 'https://self-issued.me'`);
     expect(response.code).toEqual('VCSDKVaHe23');
+    expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidRequest);
+    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Bad iss
     payload = {
@@ -53,6 +56,8 @@ describe('SiopValidation', () =>
     expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Wrong iss property in siop. Expected 'https://self-issued.me'`);
     expect(response.code).toEqual('VCSDKVaHe24');
+    expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidToken);
+    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Missing aud
     payload = {
@@ -64,6 +69,8 @@ describe('SiopValidation', () =>
     expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Missing aud property in siop`);
     expect(response.code).toEqual('VCSDKVaHe25');
+    expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidRequest);
+    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Wrong aud
     payload = {
@@ -76,6 +83,8 @@ describe('SiopValidation', () =>
     expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Wrong aud property in siop. Expected 'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/card/issue'`);
     expect(response.code).toEqual('VCSDKVaHe26');
+    expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidToken);
+    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Bad validation
     const testValidator = new DidValidation(validationOptions, expected);

--- a/tests/SiopValidation.spec.ts
+++ b/tests/SiopValidation.spec.ts
@@ -44,7 +44,6 @@ describe('SiopValidation', () =>
     expect(response.detailedError).toEqual(`Missing iss property in siop. Expected 'https://self-issued.me'`);
     expect(response.code).toEqual('VCSDKVaHe23');
     expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidRequest);
-    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Bad iss
     payload = {
@@ -57,7 +56,6 @@ describe('SiopValidation', () =>
     expect(response.detailedError).toEqual(`Wrong iss property in siop. Expected 'https://self-issued.me'`);
     expect(response.code).toEqual('VCSDKVaHe24');
     expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidToken);
-    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Missing aud
     payload = {
@@ -70,7 +68,6 @@ describe('SiopValidation', () =>
     expect(response.detailedError).toEqual(`Missing aud property in siop`);
     expect(response.code).toEqual('VCSDKVaHe25');
     expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidRequest);
-    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Wrong aud
     payload = {
@@ -84,7 +81,6 @@ describe('SiopValidation', () =>
     expect(response.detailedError).toEqual(`Wrong aud property in siop. Expected 'https://portableidentitycards.azure-api.net/42b39d9d-0cdd-4ae0-b251-b7b39a561f91/api/portable/v1.0/card/issue'`);
     expect(response.code).toEqual('VCSDKVaHe26');
     expect(response.wwwAuthenticateError).toEqual(AuthenticationErrorCode.invalidToken);
-    expect(response.realm).toEqual(VerifiableCredentialConstants.TOKEN_SI_ISS);
 
     // Bad validation
     const testValidator = new DidValidation(validationOptions, expected);

--- a/tests/TestSetup.ts
+++ b/tests/TestSetup.ts
@@ -102,7 +102,8 @@ export default class TestSetup {
     fetchRequest: new FetchRequest(),
     validationSafeguards: new ValidationSafeguards(),
     resolver: this.resolver,
-    crypto: this.crypto
+    crypto: this.crypto,
+    invalidTokenError: 401,
   };
 
   /**

--- a/tests/Validator.spec.ts
+++ b/tests/Validator.spec.ts
@@ -97,7 +97,7 @@ describe('Validator', () => {
     const splitted = siop.vc.rawToken.split('.');
     response = await validator.validate(`${splitted[0]}.${splitted[1]}.1234${splitted[2]}`);
     expect(response.result).toBeFalsy(response.detailedError);
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.code).toEqual('VCSDKVaHe27');
 });
 

--- a/tests/VerifiableCredentialValidation.spec.ts
+++ b/tests/VerifiableCredentialValidation.spec.ts
@@ -5,7 +5,7 @@
 import TestSetup from './TestSetup';
 import { IssuanceHelpers } from './IssuanceHelpers';
 import { VerifiableCredentialValidation } from '../lib/input_validation/VerifiableCredentialValidation';
-import { TokenType, IExpectedVerifiableCredential } from '../lib';
+import { TokenType, IExpectedVerifiableCredential, ValidatorBuilder } from '../lib';
 import { VerifiableCredentialValidationResponse } from '../lib/input_validation/VerifiableCredentialValidationResponse';
 const clone = require('clone');
 
@@ -62,7 +62,7 @@ describe('VerifiableCredentialValidation', () => {
     // Bad VC signature
     response = await validator.validate(siop.vc.rawToken + 'a', setup.defaultUserDid);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiableCredential is invalid');
     expect(response.code).toEqual('VCSDKVaHe27');
 

--- a/tests/VerifiablePresentationValidation.spec.ts
+++ b/tests/VerifiablePresentationValidation.spec.ts
@@ -6,7 +6,7 @@ import TestSetup from './TestSetup';
 import { VerifiablePresentationValidation } from '../lib/input_validation/VerifiablePresentationValidation';
 import { IssuanceHelpers } from './IssuanceHelpers';
 import { TokenType } from '../lib/verifiable_credential/ClaimToken';
-import { Crypto, IExpectedVerifiablePresentation } from '../lib';
+import { Crypto, IExpectedVerifiablePresentation, ValidatorBuilder } from '../lib';
 import { KeyReference } from 'verifiablecredentials-crypto-sdk-typescript';
 
 describe('VerifiablePresentationValidation', () => {
@@ -38,14 +38,14 @@ describe('VerifiablePresentationValidation', () => {
     validator = new VerifiablePresentationValidation(options, expected, 'abcdef', 'id');
     response = await validator.validate(siop.vp.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Wrong iss property in verifiablePresentation. Expected 'abcdef'`);
     expect(response.code).toEqual('VCSDKVaHe18');
 
     // Bad VP signature
     response = await validator.validate(siop.vp.rawToken + 'a');
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual('The signature on the payload in the verifiablePresentationJwt is invalid');
     expect(response.code).toEqual('VCSDKVaHe27');
 
@@ -56,7 +56,7 @@ describe('VerifiablePresentationValidation', () => {
     validator = new VerifiablePresentationValidation(options, expected, setup.defaultUserDid, 'id');
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Missing iss property in verifiablePresentation. Expected 'did:test:user'`);
     expect(response.code).toEqual('VCSDKVaHe17');
 
@@ -68,7 +68,7 @@ describe('VerifiablePresentationValidation', () => {
     siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Wrong iss property in verifiablePresentation. Expected 'did:test:user'`);
     expect(response.code).toEqual('VCSDKVaHe18');
 
@@ -84,7 +84,7 @@ describe('VerifiablePresentationValidation', () => {
     siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Missing aud property in verifiablePresentation. Expected 'did:test:issuer'`);
     expect(response.code).toEqual('VCSDKVaHe19');
 
@@ -100,7 +100,7 @@ describe('VerifiablePresentationValidation', () => {
     siopRequest = await IssuanceHelpers.createSiopRequestWithPayload(setup, payload, siop.didJwkPrivate);
     response = await validator.validate(<string>siopRequest.rawToken);
     expect(response.result).toBeFalsy();
-    expect(response.status).toEqual(403);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
     expect(response.detailedError).toEqual(`Wrong aud property in verifiablePresentation. Expected 'did:test:issuer'. Found 'test'`);
     expect(response.code).toEqual('VCSDKVaHe20');
 


### PR DESCRIPTION
**Problem:**
VC SDK hard codes the behavior when a token is invalid.  


**Solution:**
Allow this to be customizable and default to a 401 for invalid tokens.  In accordance to RFC 6750, provide a realm and error property for the WWW-Authenticate header


**Validation:**
Unit tests


**Type of change:**
- [x] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

