### PR TITLE
When a VP/VC has been revoked, return IValidatorOptions.invalidTokenError

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,9 @@
+# version 0.12.1-preview.9
+## When a VP/VC has been revoked, return IValidatorOptions.invalidTokenError
+**Type of change:** feature work
+**Customer impact:** low
+- Use IValidatorOptions.invalidTokenError for the response to a revoked VC
+
 # version 0.12.1-preview.8
 ## Performance improvements for ClaimToken.Create
 **Type of change:** feature work

--- a/lib/api_validation/VerifiablePresentationStatusReceipt.ts
+++ b/lib/api_validation/VerifiablePresentationStatusReceipt.ts
@@ -55,7 +55,7 @@ export default class VerifiablePresentationStatusReceipt {
     if (!this.receipts?.receipt) {
       return {
         result: false,
-        status: 403,
+        status: this.options.validatorOptions.invalidTokenError,
         code: errorCode(1),
         detailedError: 'The status receipt is missing receipt'
       }
@@ -74,7 +74,7 @@ export default class VerifiablePresentationStatusReceipt {
       if (receiptResponse.payloadObject.aud !== this.expected.didAudience) {
         return {
           result: false,
-          status: 403,
+          status: this.options.validatorOptions.invalidTokenError,
           detailedError: `The status receipt aud '${receiptResponse.payloadObject.aud}' is wrong. Expected '${this.expected.didAudience}'`
         }
       }
@@ -83,7 +83,7 @@ export default class VerifiablePresentationStatusReceipt {
       if (receiptResponse.issuer !== this.expected.didIssuer) {
         return {
           result: false,
-          status: 403,
+          status: this.options.validatorOptions.invalidTokenError,
           code: errorCode(2),
           detailedError: `The status receipt iss '${receiptResponse.issuer}' is wrong. Expected '${this.expected.didIssuer}'`
         }
@@ -100,7 +100,7 @@ export default class VerifiablePresentationStatusReceipt {
       if (!this.verifiablePresentationStatus![jti].passed) {
         return {
           result: false,
-          status: 403,
+          status: this.options.validatorOptions.invalidTokenError,
           code: errorCode(3),
           detailedError: `The status receipt for jti '${jti}' failed with status ${this.verifiablePresentationStatus![jti].status}.`
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.8",
+  "version": "0.12.1-preview.9",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/VerifiablePresentationStatusReceipt.spec.ts
+++ b/tests/VerifiablePresentationStatusReceipt.spec.ts
@@ -5,12 +5,11 @@
 
 import { CryptoBuilder, DidValidation, IExpectedStatusReceipt, TokenType, ValidationOptions, ValidatorBuilder, VerifiablePresentationStatusReceipt } from '../lib/index';
 
-describe('VerifiablePresentationStatusReceipt', () =>
-{
+describe('VerifiablePresentationStatusReceipt', () => {
   it('should test validate', async () => {
     let receipts = {};
     let validatorBuilder = new ValidatorBuilder(new CryptoBuilder().build());
-    let validationOptions = new ValidationOptions(<any>{}, TokenType.verifiablePresentationStatus);
+    let validationOptions = new ValidationOptions(<any>{ invalidTokenError: ValidatorBuilder.INVALID_TOKEN_STATUS_CODE }, TokenType.verifiablePresentationStatus);
     let expected: IExpectedStatusReceipt = {
       didAudience: 'didAudience',
       didIssuer: 'issuer',
@@ -31,24 +30,27 @@ describe('VerifiablePresentationStatusReceipt', () =>
 
     validator = new DidValidation(validationOptions, expected);
     let validatorSpy = spyOn(validator, "validate").and.callFake(() => {
-      return <any> {result: false};
+      return <any>{ result: false, status: ValidatorBuilder.INVALID_TOKEN_STATUS_CODE };
     });
 
-    verifiablePresentationStatusReceipt = new VerifiablePresentationStatusReceipt({receipt: [{}]}, validatorBuilder, validationOptions, expected);
+    verifiablePresentationStatusReceipt = new VerifiablePresentationStatusReceipt({ receipt: [{}] }, validatorBuilder, validationOptions, expected);
     verifiablePresentationStatusReceipt.didValidation = validator;
     let response = await verifiablePresentationStatusReceipt.validate();
-    expect(response.result).toBeFalsy(response.detailedError);    
+    expect(response.result).toBeFalsy(response.detailedError);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
 
     validatorSpy.and.callFake(() => {
-      return <any> {result: true, payloadObject: {aud: ''}};
+      return <any>{ result: true, payloadObject: { aud: '' } };
     });
     response = await verifiablePresentationStatusReceipt.validate();
-    expect(response.result).toBeFalsy(response.detailedError);    
+    expect(response.result).toBeFalsy(response.detailedError);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
 
     validatorSpy.and.callFake(() => {
-      return <any> {result: true, payloadObject: {aud: 'didAudience', issuer: ''}};
+      return <any>{ result: true, payloadObject: { aud: 'didAudience', issuer: '' } };
     });
     response = await verifiablePresentationStatusReceipt.validate();
-    expect(response.result).toBeFalsy(response.detailedError);    
+    expect(response.result).toBeFalsy(response.detailedError);
+    expect(response.status).toEqual(ValidatorBuilder.INVALID_TOKEN_STATUS_CODE);
   });
 });


### PR DESCRIPTION
Use IValidatorOptions.invalidTokenError for the response to a revoked VC
Verify with unit tests

**Problem:**
Error response for revoked VP/VC was hardcoded


**Solution:**
Use configured value


**Validation:**
Unit tests were amended


**Type of change:**
- [ ] Feature work
- [x ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

