### PR TITLE
Allow caller to skip checking required input attestations

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,4 +1,4 @@
-# version 0.12.1-preview.26
+# version 0.12.1-preview.27
 ## Allow caller to skip checking required input attestations
 **Type of change:** Feature
 **Customer impact:** low

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,4 +1,4 @@
-# version 0.12.1-preview.27
+# version 0.12.1-preview.28
 ## Allow caller to skip checking required input attestations
 **Type of change:** Feature
 **Customer impact:** low

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,4 +1,4 @@
-# version 0.12.1-preview.28
+# version 0.12.1-preview.29
 ## Allow caller to skip checking required input attestations
 **Type of change:** Feature
 **Customer impact:** low

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,9 @@
+# version 0.12.1-preview.26
+## Allow caller to skip checking required input attestations
+**Type of change:** Feature
+**Customer impact:** low
+- When attestations are checked by the caller, skip the call to validateAllRequiredInputs
+
 # version 0.12.1-preview.25
 ## Siop Validation refinements
 **Type of change:** Feature

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -53,6 +53,8 @@ export default class Validator {
       result: true,
       status: 200,
     };
+
+    let requiredTokensChecked: boolean = false;
     let claimToken: ClaimToken;
     let siopDid: string | undefined;
     let siopContractId: string | undefined;
@@ -136,6 +138,9 @@ export default class Validator {
         case TokenType.idTokenHint:
           response = await validator.validate(queue, queueItem!);
           siopDid = response.did;
+
+          // set to true if the caller checked that tokens are populated
+          requiredTokensChecked = response.tokensArePopulated ?? false;
           break;
         case TokenType.selfIssued:
           response = await validator.validate(queue, queueItem!);
@@ -163,9 +168,11 @@ export default class Validator {
     const validationResult = this.setValidationResult(queue);
 
     // Check if inputs are available
-    response = this.validateAllRequiredInputs(validationResult);
-    if (!response.result) {
-      return response;
+    if (!requiredTokensChecked) {
+      response = this.validateAllRequiredInputs(validationResult);
+      if (!response.result) {
+        return response;
+      }
     }
 
     // Check status of VCs

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -131,6 +131,8 @@ export default class Validator {
             siopContractId = Validator.readContractId(response.payloadObject.contract);
           }
 
+          // set to true if the caller checked that tokens are populated
+          requiredTokensChecked = response.tokensArePopulated ?? false;
           break;
         case TokenType.siop:
         case TokenType.siopPresentationAttestation:
@@ -138,9 +140,6 @@ export default class Validator {
         case TokenType.idTokenHint:
           response = await validator.validate(queue, queueItem!);
           siopDid = response.did;
-
-          // set to true if the caller checked that tokens are populated
-          requiredTokensChecked = response.tokensArePopulated ?? false;
           break;
         case TokenType.selfIssued:
           response = await validator.validate(queue, queueItem!);

--- a/lib/api_validation/Validator.ts
+++ b/lib/api_validation/Validator.ts
@@ -54,7 +54,6 @@ export default class Validator {
       status: 200,
     };
 
-    let requiredTokensChecked: boolean = false;
     let claimToken: ClaimToken;
     let siopDid: string | undefined;
     let siopContractId: string | undefined;
@@ -130,9 +129,6 @@ export default class Validator {
           if (response.result) {
             siopContractId = Validator.readContractId(response.payloadObject.contract);
           }
-
-          // set to true if the caller checked that tokens are populated
-          requiredTokensChecked = response.tokensArePopulated ?? false;
           break;
         case TokenType.siop:
         case TokenType.siopPresentationAttestation:
@@ -167,11 +163,9 @@ export default class Validator {
     const validationResult = this.setValidationResult(queue);
 
     // Check if inputs are available
-    if (!requiredTokensChecked) {
-      response = this.validateAllRequiredInputs(validationResult);
-      if (!response.result) {
-        return response;
-      }
+    response = this.validateAllRequiredInputs(validationResult);
+    if (!response.result) {
+      return response;
     }
 
     // Check status of VCs
@@ -190,7 +184,7 @@ export default class Validator {
     }
   }
 
-  private validateAllRequiredInputs(validationResult: IValidationResult): IValidationResponse {
+  protected validateAllRequiredInputs(validationResult: IValidationResult): IValidationResponse {
     // Check required VC's
     const requiredVCs = this.builder.trustedIssuersForVerifiableCredentials;
     if (requiredVCs) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.26",
+  "version": "0.12.1-preview.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1255,9 +1255,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.746",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.746.tgz",
-      "integrity": "sha512-3ffyGODL38apwSsIgXaWnAKNXChsjXhAmBTjbqCbrv1fBbVltuNLWh0zdrQbwK/oxPQ/Gss/kYfFAPPGu9mszQ==",
+      "version": "1.3.747",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.747.tgz",
+      "integrity": "sha512-+K1vnBc08GNYxCWwdRe9o3Ml30DhsNyK/qIl/NE1Dic+qCy9ZREcqGNiV4jiLiAdALK1DUG3pakJHGkJUd9QQw==",
       "dev": true
     },
     "elliptic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.28",
+  "version": "0.12.1-preview.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.25",
+  "version": "0.12.1-preview.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.27",
+  "version": "0.12.1-preview.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.25",
+  "version": "0.12.1-preview.26",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.27",
+  "version": "0.12.1-preview.28",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.28",
+  "version": "0.12.1-preview.29",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.26",
+  "version": "0.12.1-preview.27",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
**Problem:**
Optionality is incorrectly enforced by the VC SDK


**Solution:**
When attestations are checked by the caller, skip the call to validateAllRequiredInputs


**Validation:**
Unit tests did not detect regression


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

