### PR TITLE
Fix VC forgery bug

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,9 @@
+# version 0.12.1-preview.30
+## Prevent forgery of Verifiable Credentials
+**Type of change:** Feature
+**Customer impact:** high
+- Enforce that the iss claim of a Verifiable Credential matches the did in the kid property of the header
+
 # version 0.12.1-preview.29
 ## Allow caller to skip checking required input attestations
 **Type of change:** Feature

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,4 +1,4 @@
-# version 0.12.1-preview.30
+# version 0.12.1-preview.50
 ## Prevent forgery of Verifiable Credentials
 **Type of change:** Feature
 **Customer impact:** high

--- a/lib/input_validation/VerifiableCredentialValidation.ts
+++ b/lib/input_validation/VerifiableCredentialValidation.ts
@@ -42,6 +42,26 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       return validationResponse;
     }
 
+    // the issuer of the VC must match the DID that provided the keys
+    // otherwise you can claim a VC came from another issuer
+    if (!validationResponse.issuer) {
+      return {
+        result: false,
+        code: errorCode(17),
+        detailedError: 'The verifiable credential has not defined an issuer',
+        status: this.options.validatorOptions.invalidTokenError,
+      };
+    }
+
+    if (validationResponse.did !== validationResponse.issuer) {
+      return {
+        result: false,
+        code: errorCode(18),
+        detailedError: 'The issuer of the Verifiable Credential is invalid',
+        status: this.options.validatorOptions.invalidTokenError,
+      };
+    }
+
     const isJwt = typeof verifiableCredential === 'string';
     if (isJwt) {
       validationResponse.subject = validationResponse.payloadObject.sub;
@@ -147,7 +167,7 @@ export class VerifiableCredentialValidation implements IVerifiableCredentialVali
       }
 
       // Check if the we found a matching contract.
-      if (!vcIssuers.includes(validationResponse.issuer!)) {
+      if (!vcIssuers.includes(validationResponse.issuer)) {
         return {
           result: false,
           code: errorCode(12),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.30",
+  "version": "0.12.1-preview.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.29",
+  "version": "0.12.1-preview.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.29",
+  "version": "0.12.1-preview.30",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-verification-sdk-typescript",
-  "version": "0.12.1-preview.30",
+  "version": "0.12.1-preview.50",
   "description": "Typescript SDK for verifiable credentials",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
**Problem:**
VC SDK allows the iss claim of a VC JWT to be different than the did which signed the token, allowing for forged VCs to be accepted


**Solution:**
Enforce that iss and the did in the kid property of the header are the same


**Validation:**
Added new unit tests


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

